### PR TITLE
Add commands to get/ set charge limit and FP brightness

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,13 @@ All of these need EC communication support in order to work.
 - [x] Get information about CCGX PD Controllers (`--pd-info`)
 - [x] Show status of intrusion switches (`--intrusion`)
 - [x] Show status of privacy switches (`--privacy`)
+- [x] Check recent EC console output (`--console recent`)
+
+###### Changing settings
+
+- [x] Get and set keyboard brightness (`--kblight`)
+- [x] Get and set battery charge limit (`--charge-limit`)
+- [x] Get and set fingerprint LED brightness (`--fp-brightness`)
 
 ###### Communication with Embedded Controller
 

--- a/framework_lib/src/chromium_ec/command.rs
+++ b/framework_lib/src/chromium_ec/command.rs
@@ -32,6 +32,8 @@ pub enum EcCommands {
     FlashNotified = 0x3E01,
     /// Change charge limit
     ChargeLimitControl = 0x3E03,
+    /// Get/Set Fingerprint LED brightness
+    FpLedLevelControl = 0x3E0E,
     /// Get information about the current chassis open/close status
     ChassisOpenCheck = 0x3E0F,
     /// Get information about historical chassis open/close (intrusion) information

--- a/framework_lib/src/chromium_ec/command.rs
+++ b/framework_lib/src/chromium_ec/command.rs
@@ -30,6 +30,8 @@ pub enum EcCommands {
     // Framework specific commands
     /// Configure the behavior of the flash notify
     FlashNotified = 0x3E01,
+    /// Change charge limit
+    ChargeLimitControl = 0x3E03,
     /// Get information about the current chassis open/close status
     ChassisOpenCheck = 0x3E0F,
     /// Get information about historical chassis open/close (intrusion) information

--- a/framework_lib/src/chromium_ec/commands.rs
+++ b/framework_lib/src/chromium_ec/commands.rs
@@ -359,3 +359,41 @@ impl EcRequest<EcResponseGetHwDiag> for EcRequestGetHwDiag {
         EcCommands::GetHwDiag
     }
 }
+
+#[repr(u8)]
+pub enum ChargeLimitControlModes {
+    /// Disable all settings, handled automatically
+    Disable = 0x01,
+    /// Set maxiumum and minimum percentage
+    Set = 0x02,
+    /// Get current setting
+    /// ATTENTION!!! This is the only mode that will return a response
+    Get = 0x08,
+    /// Allow charge to full this time
+    Override = 0x80,
+}
+
+#[repr(C, packed)]
+pub struct EcRequestChargeLimitControl {
+    pub modes: u8,
+    pub max_percentage: u8,
+    pub min_percentage: u8,
+}
+
+#[repr(C, packed)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct EcResponseChargeLimitControl {
+    pub max_percentage: u8,
+    pub min_percentage: u8,
+}
+
+impl EcRequest<EcResponseChargeLimitControl> for EcRequestChargeLimitControl {
+    fn command_id() -> EcCommands {
+        EcCommands::ChargeLimitControl
+    }
+}
+
+/*
+ * Configure the behavior of the charge limit control.
+ */
+pub const EC_CHARGE_LIMIT_RESTORE: u8 = 0x7F;

--- a/framework_lib/src/chromium_ec/commands.rs
+++ b/framework_lib/src/chromium_ec/commands.rs
@@ -1,3 +1,5 @@
+use num_derive::FromPrimitive;
+
 use super::{command::*, input_deck::INPUT_DECK_SLOTS};
 
 #[repr(C, packed)]
@@ -395,5 +397,34 @@ impl EcRequest<EcResponseChargeLimitControl> for EcRequestChargeLimitControl {
 
 /*
  * Configure the behavior of the charge limit control.
+ * TODO: Use this
  */
 pub const EC_CHARGE_LIMIT_RESTORE: u8 = 0x7F;
+
+#[repr(u8)]
+#[derive(Debug, FromPrimitive)]
+pub enum FpLedBrightnessLevel {
+    High = 0,
+    Medium = 1,
+    Low = 2,
+}
+
+#[repr(C, packed)]
+pub struct EcRequestFpLedLevelControl {
+    /// See enum FpLedBrightnessLevel
+    pub set_level: u8,
+    /// Boolean. >1 to get the level
+    pub get_level: u8,
+}
+
+#[repr(C, packed)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct EcResponseFpLedLevelControl {
+    pub level: u8,
+}
+
+impl EcRequest<EcResponseFpLedLevelControl> for EcRequestFpLedLevelControl {
+    fn command_id() -> EcCommands {
+        EcCommands::FpLedLevelControl
+    }
+}

--- a/framework_lib/src/chromium_ec/mod.rs
+++ b/framework_lib/src/chromium_ec/mod.rs
@@ -256,6 +256,29 @@ impl CrosEc {
         Ok((limits.min_percentage, limits.max_percentage))
     }
 
+    pub fn set_fp_led_level(&self, level: FpLedBrightnessLevel) -> EcResult<()> {
+        // Sending bytes manually because the Set command, as opposed to the Get command,
+        // does not return any data
+        let limits = &[level as u8, 0x00];
+        let data = self.send_command(EcCommands::FpLedLevelControl as u16, 0, limits)?;
+        assert_eq!(data.len(), 0);
+
+        Ok(())
+    }
+
+    /// Get fingerprint led brightness level
+    pub fn get_fp_led_level(&self) -> EcResult<u8> {
+        let res = EcRequestFpLedLevelControl {
+            set_level: 0xFF,
+            get_level: 0xFF,
+        }
+        .send_command(self)?;
+
+        debug!("Level Raw: {}", res.level);
+
+        Ok(res.level)
+    }
+
     /// Get the intrusion switch status (whether the chassis is open or not)
     pub fn get_intrusion_status(&self) -> EcResult<IntrusionStatus> {
         let status = EcRequestChassisOpenCheck {}.send_command(self)?;

--- a/framework_lib/src/commandline/clap_std.rs
+++ b/framework_lib/src/commandline/clap_std.rs
@@ -4,7 +4,7 @@
 use clap::Parser;
 
 use crate::chromium_ec::CrosEcDriverType;
-use crate::commandline::{Cli, ConsoleArg, InputDeckModeArg};
+use crate::commandline::{Cli, ConsoleArg, FpBrightnessArg, InputDeckModeArg};
 
 /// Swiss army knife for Framework laptops
 #[derive(Parser)]
@@ -93,6 +93,10 @@ struct ClapCli {
     #[arg(long)]
     charge_limit: Option<Option<u8>>,
 
+    /// Get or set fingerprint LED brightness
+    #[arg(long)]
+    fp_brightness: Option<Option<FpBrightnessArg>>,
+
     /// Set keyboard backlight percentage or get, if no value provided
     #[arg(long)]
     kblight: Option<Option<u8>>,
@@ -147,6 +151,7 @@ pub fn parse(args: &[String]) -> Cli {
         inputmodules: args.inputmodules,
         input_deck_mode: args.input_deck_mode,
         charge_limit: args.charge_limit,
+        fp_brightness: args.fp_brightness,
         kblight: args.kblight,
         console: args.console,
         driver: args.driver,

--- a/framework_lib/src/commandline/clap_std.rs
+++ b/framework_lib/src/commandline/clap_std.rs
@@ -89,6 +89,10 @@ struct ClapCli {
     #[arg(long)]
     input_deck_mode: Option<InputDeckModeArg>,
 
+    /// Get or set max charge limit
+    #[arg(long)]
+    charge_limit: Option<Option<u8>>,
+
     /// Set keyboard backlight percentage or get, if no value provided
     #[arg(long)]
     kblight: Option<Option<u8>>,
@@ -142,6 +146,7 @@ pub fn parse(args: &[String]) -> Cli {
         intrusion: args.intrusion,
         inputmodules: args.inputmodules,
         input_deck_mode: args.input_deck_mode,
+        charge_limit: args.charge_limit,
         kblight: args.kblight,
         console: args.console,
         driver: args.driver,

--- a/framework_lib/src/commandline/mod.rs
+++ b/framework_lib/src/commandline/mod.rs
@@ -29,6 +29,7 @@ use crate::ccgx::hid::{check_ccg_fw_version, find_devices, DP_CARD_PID, HDMI_CAR
 use crate::ccgx::{self, SiliconId::*};
 use crate::chromium_ec;
 use crate::chromium_ec::commands::DeckStateMode;
+use crate::chromium_ec::commands::FpLedBrightnessLevel;
 use crate::chromium_ec::print_err;
 use crate::chromium_ec::EcError;
 use crate::chromium_ec::EcResult;
@@ -56,6 +57,23 @@ use core::prelude::rust_2021::derive;
 pub enum ConsoleArg {
     Recent,
     Follow,
+}
+
+#[cfg_attr(not(feature = "uefi"), derive(clap::ValueEnum))]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum FpBrightnessArg {
+    High,
+    Medium,
+    Low,
+}
+impl From<FpBrightnessArg> for FpLedBrightnessLevel {
+    fn from(w: FpBrightnessArg) -> FpLedBrightnessLevel {
+        match w {
+            FpBrightnessArg::High => FpLedBrightnessLevel::High,
+            FpBrightnessArg::Medium => FpLedBrightnessLevel::Medium,
+            FpBrightnessArg::Low => FpLedBrightnessLevel::Low,
+        }
+    }
 }
 
 #[cfg_attr(not(feature = "uefi"), derive(clap::ValueEnum))]
@@ -103,6 +121,7 @@ pub struct Cli {
     pub inputmodules: bool,
     pub input_deck_mode: Option<InputDeckModeArg>,
     pub charge_limit: Option<Option<u8>>,
+    pub fp_brightness: Option<Option<FpBrightnessArg>>,
     pub kblight: Option<Option<u8>>,
     pub console: Option<ConsoleArg>,
     pub help: bool,
@@ -440,6 +459,8 @@ pub fn run_with_args(args: &Cli, _allupdate: bool) -> i32 {
         ec.set_input_deck_mode((*mode).into()).unwrap();
     } else if let Some(maybe_limit) = args.charge_limit {
         print_err(handle_charge_limit(&ec, maybe_limit));
+    } else if let Some(maybe_brightness) = &args.fp_brightness {
+        print_err(handle_fp_brightness(&ec, *maybe_brightness));
     } else if let Some(Some(kblight)) = args.kblight {
         assert!(kblight <= 100);
         ec.set_keyboard_backlight(kblight);
@@ -861,6 +882,17 @@ fn handle_charge_limit(ec: &CrosEc, maybe_limit: Option<u8>) -> EcResult<()> {
 
     let (min, max) = ec.get_charge_limit()?;
     println!("Minimum {}%, Maximum {}%", min, max);
+
+    Ok(())
+}
+
+fn handle_fp_brightness(ec: &CrosEc, maybe_brightness: Option<FpBrightnessArg>) -> EcResult<()> {
+    if let Some(brightness) = maybe_brightness {
+        ec.set_fp_led_level(brightness.into())?;
+    }
+
+    let level = ec.get_fp_led_level()?;
+    println!("Fingerprint LED Brightness: {:?}%", level);
 
     Ok(())
 }

--- a/framework_lib/src/commandline/mod.rs
+++ b/framework_lib/src/commandline/mod.rs
@@ -648,6 +648,8 @@ Options:
       --capsule <CAPSULE>    Parse UEFI Capsule information from binary file
       --intrusion            Show status of intrusion switch
       --inputmodules         Show status of the input modules (Framework 16 only)
+      --charge-limit [<VAL>] Get or set battery charge limit (Percentage number as arg, e.g. '100')
+      --fp-brightness [<VAL>]Get or set fingerprint LED brightness level [possible values: high, medium, low]
       --kblight [<KBLIGHT>]  Set keyboard backlight percentage or get, if no value provided
       --console <CONSOLE>    Get EC console, choose whether recent or to follow the output [possible values: recent, follow]
   -t, --test                 Run self-test to check if interaction with EC is possible

--- a/framework_lib/src/commandline/uefi.rs
+++ b/framework_lib/src/commandline/uefi.rs
@@ -73,6 +73,7 @@ pub fn parse(args: &[String]) -> Cli {
         intrusion: false,
         inputmodules: false,
         input_deck_mode: None,
+        charge_limit: None,
         kblight: None,
         console: None,
         // This is the only driver that works on UEFI
@@ -149,6 +150,21 @@ pub fn parse(args: &[String]) -> Cli {
                     "Need to provide a value for --input-deck-mode. Either `auto`, `off`, or `on`"
                 );
                 None
+            };
+            found_an_option = true;
+        } else if arg == "--charge-limit" {
+            cli.charge_limit = if args.len() > i + 1 {
+                if let Ok(percent) = args[i + 1].parse::<u8>() {
+                    Some(Some(percent))
+                } else {
+                    println!(
+                        "Invalid value for --charge_limit: '{}'. Must be integer < 100.",
+                        args[i + 1]
+                    );
+                    None
+                }
+            } else {
+                Some(None)
             };
             found_an_option = true;
         } else if arg == "--kblight" {

--- a/framework_lib/src/commandline/uefi.rs
+++ b/framework_lib/src/commandline/uefi.rs
@@ -12,7 +12,7 @@ use uefi::Identify;
 use crate::chromium_ec::CrosEcDriverType;
 use crate::commandline::Cli;
 
-use super::{ConsoleArg, InputDeckModeArg};
+use super::{ConsoleArg, FpBrightnessArg, InputDeckModeArg};
 
 /// Get commandline arguments from UEFI environment
 pub fn get_args(boot_services: &BootServices) -> Vec<String> {
@@ -74,6 +74,7 @@ pub fn parse(args: &[String]) -> Cli {
         inputmodules: false,
         input_deck_mode: None,
         charge_limit: None,
+        fp_brightness: None,
         kblight: None,
         console: None,
         // This is the only driver that works on UEFI
@@ -176,6 +177,23 @@ pub fn parse(args: &[String]) -> Cli {
                         "Invalid value for --kblight: '{}'. Must be integer < 100.",
                         args[i + 1]
                     );
+                    None
+                }
+            } else {
+                Some(None)
+            };
+            found_an_option = true;
+        } else if arg == "--fp-brightness" {
+            cli.fp_brightness = if args.len() > i + 1 {
+                let fp_brightness_arg = &args[i + 1];
+                if fp_brightness_arg == "high" {
+                    Some(Some(FpBrightnessArg::High))
+                } else if fp_brightness_arg == "medium" {
+                    Some(Some(FpBrightnessArg::Medium))
+                } else if fp_brightness_arg == "low" {
+                    Some(Some(FpBrightnessArg::Low))
+                } else {
+                    println!("Invalid value for --fp-brightness: {}", fp_brightness_arg);
                     None
                 }
             } else {


### PR DESCRIPTION
The minimum limit cannot be changed.

Tested on platforms:
- Intel 12th Gen with BIOS 3.07
- AMD 13th inch with BIOS 3.04

Tested with drivers:
- portio on UEFI Shell
- portio on Linux
- cros_ec on Linux

Examples:

```
> framework_tool --driver portio --charge-limit
Minimum 0%, Maximum 100%

> framework_tool --charge-limit 90
Minimum 0%, Maximum 90%

> framework_tool --driver portio --fp-brightness
Fingerprint LED Brightness: 55%

> framework_tool --fp-brightness low
Fingerprint LED Brightness: 15%
```

Fixes #5 