### PR TITLE
ccgx: Use same CrosEc driver as everywhere else

### DIFF
--- a/framework_lib/src/ccgx/device.rs
+++ b/framework_lib/src/ccgx/device.rs
@@ -72,6 +72,7 @@ impl PdPort {
 
 pub struct PdController {
     port: PdPort,
+    ec: CrosEc,
 }
 
 fn passthrough_offset(dev_index: u16) -> u16 {
@@ -159,15 +160,15 @@ pub fn decode_flash_row_size(mode_byte: u8) -> u16 {
 }
 
 impl PdController {
-    pub fn new(port: PdPort) -> Self {
-        PdController { port }
+    pub fn new(port: PdPort, ec: CrosEc) -> Self {
+        PdController { port, ec }
     }
     /// Wrapped with support for dev id
     /// TODO: Should move into chromium_ec module
     /// TODO: Must not call CrosEc::new() otherwise the driver isn't configurable!
     fn send_ec_command(&self, code: u16, dev_index: u16, data: &[u8]) -> EcResult<Vec<u8>> {
         let command_id = code + passthrough_offset(dev_index);
-        CrosEc::new().send_command(command_id, 0, data)
+        self.ec.send_command(command_id, 0, data)
     }
 
     fn i2c_read(&self, addr: u16, len: u16) -> EcResult<EcI2cPassthruResponse> {

--- a/framework_lib/src/ccgx/device.rs
+++ b/framework_lib/src/ccgx/device.rs
@@ -311,7 +311,7 @@ impl PdController {
         let base_ver = BaseVersion::from(&data[..4]);
         let app_ver = AppVersion::from(&data[4..]);
         println!(
-            "  Bootloader Version: Base: {},  App: {}",
+            "  Bootloader Version:   Base: {},  App: {}",
             base_ver, app_ver
         );
 

--- a/framework_lib/src/ccgx/mod.rs
+++ b/framework_lib/src/ccgx/mod.rs
@@ -117,7 +117,7 @@ impl fmt::Display for BaseVersion {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "{}.{}.{}.{}",
+            "{}.{}.{}.{:0>3}",
             self.major, self.minor, self.patch, self.build_number
         )
     }
@@ -161,7 +161,7 @@ impl fmt::Display for AppVersion {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "{}.{}.{} ({:?})",
+            "{}.{}.{:0>2} ({:?})",
             self.major, self.minor, self.circuit, self.application
         )
     }

--- a/framework_lib/src/ccgx/mod.rs
+++ b/framework_lib/src/ccgx/mod.rs
@@ -5,7 +5,7 @@ use core::prelude::rust_2021::derive;
 use num_derive::FromPrimitive;
 use std::fmt;
 
-use crate::chromium_ec::EcResult;
+use crate::chromium_ec::{CrosEc, EcResult};
 
 use self::device::{PdController, PdPort};
 
@@ -214,10 +214,10 @@ pub struct MainPdVersions {
     pub controller23: ControllerVersion,
 }
 
-pub fn get_pd_controller_versions() -> EcResult<PdVersions> {
+pub fn get_pd_controller_versions(ec: &CrosEc) -> EcResult<PdVersions> {
     Ok(PdVersions {
-        controller01: PdController::new(PdPort::Left01).get_fw_versions()?,
-        controller23: PdController::new(PdPort::Right23).get_fw_versions()?,
+        controller01: PdController::new(PdPort::Left01, ec.clone()).get_fw_versions()?,
+        controller23: PdController::new(PdPort::Right23, ec.clone()).get_fw_versions()?,
     })
 }
 

--- a/framework_lib/src/chromium_ec/mod.rs
+++ b/framework_lib/src/chromium_ec/mod.rs
@@ -100,6 +100,7 @@ pub trait CrosEcDriver {
     fn send_command(&self, command: u16, command_version: u8, data: &[u8]) -> EcResult<Vec<u8>>;
 }
 
+#[derive(Clone)]
 pub struct CrosEc {
     driver: CrosEcDriverType,
 }

--- a/framework_lib/src/commandline/mod.rs
+++ b/framework_lib/src/commandline/mod.rs
@@ -133,13 +133,13 @@ fn print_single_pd_details(pd: &PdController) {
     pd.print_fw_info();
 }
 
-fn print_pd_details() {
+fn print_pd_details(ec: &CrosEc) {
     if !is_framework() {
         println!("Only supported on Framework systems");
         return;
     }
-    let pd_01 = PdController::new(PdPort::Left01);
-    let pd_23 = PdController::new(PdPort::Right23);
+    let pd_01 = PdController::new(PdPort::Left01, ec.clone());
+    let pd_23 = PdController::new(PdPort::Right23, ec.clone());
 
     println!("Left / Ports 01");
     print_single_pd_details(&pd_01);
@@ -271,7 +271,7 @@ fn print_versions(ec: &CrosEc) {
 
     println!("PD Controllers");
 
-    if let Ok(pd_versions) = ccgx::get_pd_controller_versions() {
+    if let Ok(pd_versions) = ccgx::get_pd_controller_versions(ec) {
         println!("  Right (01)");
         println!(
             "    Main   App:     {}",
@@ -469,7 +469,7 @@ pub fn run_with_args(args: &Cli, _allupdate: bool) -> i32 {
     } else if args.info {
         smbios_info();
     } else if args.pd_info {
-        print_pd_details();
+        print_pd_details(&ec);
     } else if args.dp_hdmi_info {
         #[cfg(not(feature = "uefi"))]
         print_dp_hdmi_details();
@@ -679,8 +679,8 @@ fn selftest(ec: &CrosEc) -> Option<()> {
     // Try to get PD versions through EC
     power::read_pd_version(ec).ok()?;
 
-    let pd_01 = PdController::new(PdPort::Left01);
-    let pd_23 = PdController::new(PdPort::Right23);
+    let pd_01 = PdController::new(PdPort::Left01, ec.clone());
+    let pd_23 = PdController::new(PdPort::Right23, ec.clone());
     println!("  Getting PD01 info");
     print_err(pd_01.get_silicon_id())?;
     print_err(pd_01.get_device_info())?;

--- a/framework_lib/src/commandline/mod.rs
+++ b/framework_lib/src/commandline/mod.rs
@@ -342,6 +342,8 @@ fn print_versions(ec: &CrosEc) {
         if let Ok(csme) = csme::csme_from_sysfs() {
             println!("  Enabled:        {}", csme.enabled);
             println!("  Version:        {}", csme.version);
+        } else {
+            println!("  Unknown");
         }
     }
 }


### PR DESCRIPTION
Fixes ccgx info on AMD systems where the cros_ec driver doesn't work yet.