### PR TITLE
ccgx: Lign up Version info nicely

### DIFF
--- a/framework_lib/src/ccgx/device.rs
+++ b/framework_lib/src/ccgx/device.rs
@@ -311,7 +311,7 @@ impl PdController {
         let base_ver = BaseVersion::from(&data[..4]);
         let app_ver = AppVersion::from(&data[4..]);
         println!(
-            "  Bootloader Version: Base: {},  App: {}",
+            "  Bootloader Version:   Base: {},  App: {}",
             base_ver, app_ver
         );
 

--- a/framework_lib/src/ccgx/mod.rs
+++ b/framework_lib/src/ccgx/mod.rs
@@ -161,7 +161,7 @@ impl fmt::Display for AppVersion {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "{}.{}.{} ({:?})",
+            "{}.{}.{:0>2} ({:?})",
             self.major, self.minor, self.circuit, self.application
         )
     }


### PR DESCRIPTION
Before:

```
Left / Ports 01
  Silicon ID:     0x3000
  Mode:           MainFw
  Flash Row Size: 128 B
  Bootloader Version: Base: 3.4.0.420,  App: 0.0.2 (Notebook)
  FW1 (Backup) Version: Base: 3.4.0.425,  App: 0.1.44 (Notebook)
  FW2 (Main)   Version: Base: 3.4.0.425,  App: 0.1.44 (Notebook)
```

After:

```
Left / Ports 01
  Silicon ID:     0x3000
  Mode:           MainFw
  Flash Row Size: 128 B
  Bootloader Version:   Base: 3.4.0.420,  App: 0.0.02 (Notebook)
  FW1 (Backup) Version: Base: 3.4.0.425,  App: 0.1.44 (Notebook)
  FW2 (Main)   Version: Base: 3.4.0.425,  App: 0.1.44 (Notebook)
```