### PR TITLE
chromium_ec: Add ReducedPowerInfo 

### DIFF
--- a/framework_lib/src/chromium_ec/commands.rs
+++ b/framework_lib/src/chromium_ec/commands.rs
@@ -313,7 +313,7 @@ pub const BOARD_VERSION_15: u8 = 15;
 pub struct EcRequestExpansionBayStatus {}
 
 #[repr(C, packed)]
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct EcResponseExpansionBayStatus {
     pub state: u8,
     pub board_id_0: u8,

--- a/framework_lib/src/chromium_ec/input_deck.rs
+++ b/framework_lib/src/chromium_ec/input_deck.rs
@@ -130,7 +130,7 @@ impl From<u8> for InputDeckState {
     }
 }
 
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct InputDeckStatus {
     pub state: InputDeckState,
     pub hubboard_present: bool,
@@ -197,7 +197,7 @@ impl From<EcResponseDeckState> for InputDeckStatus {
     }
 }
 
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct TopRowPositions {
     /// C1 all the way left
     /// B1 all the way left

--- a/framework_lib/src/power.rs
+++ b/framework_lib/src/power.rs
@@ -97,6 +97,40 @@ pub struct PowerInfo {
     pub battery: Option<BatteryInformation>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReducedBatteryInformation {
+    pub cycle_count: u32,
+    pub charge_percentage: u32, // Calculated based on Remaining Capacity / LFCC
+    pub charging: bool,
+}
+
+/// Reduced version of PowerInfo
+///
+/// Usually you won't need all of the fields.
+/// Some of them (e.g. present_voltage) will vary with a high frequency, so it's not good to
+/// compare two PowerInfo structs to see whether the battery status has changed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReducedPowerInfo {
+    pub ac_present: bool,
+    pub battery: Option<ReducedBatteryInformation>,
+}
+impl From<PowerInfo> for ReducedPowerInfo {
+    fn from(val: PowerInfo) -> Self {
+        ReducedPowerInfo {
+            ac_present: val.ac_present,
+            battery: if let Some(b) = val.battery {
+                Some(ReducedBatteryInformation {
+                    cycle_count: b.cycle_count,
+                    charge_percentage: b.charge_percentage,
+                    charging: b.charging,
+                })
+            } else {
+                None
+            },
+        }
+    }
+}
+
 fn read_string(ec: &CrosEc, address: u16) -> String {
     let bytes = ec.read_memory(address, EC_MEMMAP_TEXT_MAX).unwrap();
     String::from_utf8_lossy(bytes.as_slice()).replace(|c: char| c == '\0', "")


### PR DESCRIPTION
For when PowerInfo has too many fields and you want to compare only the
main information to see if the battery state has changed.