### PR TITLE
Allow flashing EC firmware

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "built"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -180,6 +189,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "cxx"
 version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -234,6 +262,16 @@ dependencies = [
  "quote",
  "rustc_version",
  "syn 1.0.107",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -301,6 +339,7 @@ dependencies = [
  "redox_hwio",
  "regex",
  "rusb",
+ "sha2",
  "smbios-lib",
  "spin 0.9.4",
  "uefi",
@@ -323,6 +362,16 @@ dependencies = [
  "log",
  "uefi",
  "uefi-services",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -904,6 +953,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "smbios-lib"
 version = "0.9.1"
 source = "git+https://github.com/FrameworkComputer/smbios-lib.git?branch=no-std#b3e2fff8a6f4b8c2d729467cbbf0c8c41974cd1c"
@@ -994,6 +1054,12 @@ checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "ucs2"

--- a/framework_lib/Cargo.toml
+++ b/framework_lib/Cargo.toml
@@ -14,7 +14,13 @@ linux = ["linux_pio", "unix"]
 windows = ["std", "smbios", "dep:windows", "win_driver"]
 smbios = ["dep:smbios-lib"]
 std = ["dep:regex", "dep:clap", "dep:clap-verbosity-flag", "dep:env_logger", "smbios-lib?/std", "dep:hidapi", "dep:rusb"]
-uefi = ["dep:plain", "raw_pio", "smbios", "lazy_static/spin_no_std", "dep:uefi", "dep:uefi-services"]
+uefi = [
+    "dep:plain", "raw_pio", "smbios", "lazy_static/spin_no_std", "dep:uefi", "dep:uefi-services",
+    # Otherwise I get: `LLVM ERROR: Do not know how to split the result of this operator!`
+    # Seems to be a Ruset/LLVM bug when SSE is enabled.
+    # See: https://github.com/rust-lang/rust/issues/61721
+    "sha2/force-soft"
+]
 
 # EC communication via Port I/O on Linux
 linux_pio = ["dep:libc"]
@@ -31,6 +37,7 @@ built = { version = "0.5", features = ["chrono", "git2"] }
 
 [dependencies]
 lazy_static = "1.4.0"
+sha2 = { version = "0.10.6", default_features = false, features = [ "force-soft" ] }
 regex = { version = "1.6.0", optional = true } # TODO: Can update to 1.7.0
 redox_hwio = { version = "0.1.5", default_features = false }
 libc = { version = "0.2.137", optional = true }

--- a/framework_lib/src/chromium_ec/command.rs
+++ b/framework_lib/src/chromium_ec/command.rs
@@ -93,14 +93,14 @@ impl<T: EcRequest<R>, R> EcRequestRaw<R> for T {
     fn command_id_u16() -> u16 {
         Self::command_id() as u16
     }
+    fn command_version() -> u8 {
+        Self::command_version()
+    }
 }
 
 pub trait EcRequestRaw<R> {
     fn command_id_u16() -> u16;
-    // Can optionally override this
-    fn command_version() -> u8 {
-        0
-    }
+    fn command_version() -> u8;
 
     fn format_request(&self) -> &[u8]
     where
@@ -160,7 +160,7 @@ pub trait EcRequestRaw<R> {
         let expected = response.len() != std::mem::size_of::<R>();
         if expected {
             return Err(EcError::DeviceError(format!(
-                "Returned data size {} is not the expted size: {}",
+                "Returned data size ({}) is not the expted size: {}",
                 response.len(),
                 std::mem::size_of::<R>()
             )));

--- a/framework_lib/src/chromium_ec/command.rs
+++ b/framework_lib/src/chromium_ec/command.rs
@@ -20,10 +20,14 @@ pub enum EcCommands {
     /// Command to read data from EC memory map
     ReadMemMap = 0x07,
     GetCmdVersions = 0x08,
-    /// Read section of EC flash
+    FlashInfo = 0x10,
+    /// Write section of EC flash
     FlashRead = 0x11,
     /// Write section of EC flash
     FlashWrite = 0x12,
+    /// Erase section of EC flash
+    FlashErase = 0x13,
+    FlashProtect = 0x15,
     PwmGetKeyboardBacklight = 0x0022,
     PwmSetKeyboardBacklight = 0x0023,
     I2cPassthrough = 0x9e,

--- a/framework_lib/src/chromium_ec/command.rs
+++ b/framework_lib/src/chromium_ec/command.rs
@@ -20,6 +20,10 @@ pub enum EcCommands {
     /// Command to read data from EC memory map
     ReadMemMap = 0x07,
     GetCmdVersions = 0x08,
+    /// Read section of EC flash
+    FlashRead = 0x11,
+    /// Write section of EC flash
+    FlashWrite = 0x12,
     PwmGetKeyboardBacklight = 0x0022,
     PwmSetKeyboardBacklight = 0x0023,
     I2cPassthrough = 0x9e,

--- a/framework_lib/src/chromium_ec/commands.rs
+++ b/framework_lib/src/chromium_ec/commands.rs
@@ -77,6 +77,9 @@ pub struct EcResponseFlashInfo {
 }
 
 impl EcRequest<EcResponseFlashInfo> for EcRequestFlashInfo {
+    fn command_version() -> u8 {
+        1
+    }
     fn command_id() -> EcCommands {
         EcCommands::FlashInfo
     }

--- a/framework_lib/src/chromium_ec/commands.rs
+++ b/framework_lib/src/chromium_ec/commands.rs
@@ -60,6 +60,17 @@ impl EcRequest<EcResponseGetCmdVersionsV1> for EcRequestGetCmdVersionsV1 {
     }
 }
 
+pub struct EcRequestFlashRead {
+    pub offset: u32,
+    pub size: u32,
+}
+
+impl EcRequest<()> for EcRequestFlashRead {
+    fn command_id() -> EcCommands {
+        EcCommands::FlashRead
+    }
+}
+
 #[repr(C, packed)]
 pub struct EcRequestPwmSetKeyboardBacklight {
     pub percent: u8,

--- a/framework_lib/src/chromium_ec/mod.rs
+++ b/framework_lib/src/chromium_ec/mod.rs
@@ -545,7 +545,11 @@ impl CrosEc {
         for chunk_no in 0..chunks {
             #[cfg(feature = "uefi")]
             if shell_get_execution_break_flag() {
-                return Err(EcError::DeviceError("Execution interrupted".to_string()));
+                // TODO: We don't want to crash here. But returning no data doesn't seem optimal
+                // either
+                // return Err(EcError::DeviceError("Execution interrupted".to_string()));
+                println!("Execution interrupted");
+                return Ok(vec![]);
             }
 
             let offset = offset + chunk_no * chunk_size;

--- a/framework_lib/src/chromium_ec/mod.rs
+++ b/framework_lib/src/chromium_ec/mod.rs
@@ -176,11 +176,11 @@ impl CrosEc {
         match self.read_memory(EC_MEMMAP_ID, 2) {
             Some(ec_id) => {
                 if ec_id.len() != 2 {
-                    println!("  Unexpected length returned: {:?}", ec_id.len());
+                    error!("  Unexpected length returned: {:?}", ec_id.len());
                     return None;
                 }
                 if ec_id[0] != b'E' || ec_id[1] != b'C' {
-                    println!("  This machine doesn't look like it has a Framework EC");
+                    error!("  This machine doesn't look like it has a Framework EC");
                     None
                 } else {
                     println!("  Verified that Framework EC is present!");
@@ -188,7 +188,7 @@ impl CrosEc {
                 }
             }
             None => {
-                println!("  Failed to read EC ID from memory map");
+                error!("  Failed to read EC ID from memory map");
                 None
             }
         }
@@ -361,7 +361,7 @@ impl CrosEc {
         // The enabled field is deprecated and must always be 1
         debug_assert_eq!(kblight.enabled, 1);
         if !kblight.enabled == 0 {
-            println!("Should always be enabled, even if OFF");
+            error!("Should always be enabled, even if OFF");
         }
 
         Ok(kblight.percent)
@@ -623,7 +623,7 @@ impl CrosEc {
                     console.push_str(ascii.as_str());
                 }
                 Err(err) => {
-                    println!("Err: {:?}", err);
+                    error!("Err: {:?}", err);
                     return Ok(console);
                     //return Err(err)
                 }

--- a/framework_lib/src/chromium_ec/portio.rs
+++ b/framework_lib/src/chromium_ec/portio.rs
@@ -1,5 +1,4 @@
 use crate::chromium_ec::{EcError, EcResponseStatus, EcResult};
-use crate::smbios;
 use alloc::format;
 use alloc::string::ToString;
 use alloc::vec;
@@ -15,16 +14,9 @@ use num::FromPrimitive;
 #[cfg(feature = "linux_pio")]
 use std::sync::{Arc, Mutex};
 
-use crate::chromium_ec::portio_mec;
+use crate::chromium_ec::{has_mec, portio_mec};
 use crate::os_specific;
-use crate::util::{self, Platform};
-
-fn has_mec() -> bool {
-    !matches!(
-        smbios::get_platform().unwrap(),
-        Platform::Framework13Amd | Platform::Framework16
-    )
-}
+use crate::util;
 
 /*
  * Value written to legacy command port / prefix byte to indicate protocol

--- a/framework_lib/src/commandline/clap_std.rs
+++ b/framework_lib/src/commandline/clap_std.rs
@@ -77,6 +77,10 @@ struct ClapCli {
     #[arg(long)]
     ho2_capsule: Option<std::path::PathBuf>,
 
+    /// Dump EC flash contents
+    #[arg(long)]
+    dump_ec_flash: Option<std::path::PathBuf>,
+
     /// Show status of intrusion switch
     #[arg(long)]
     intrusion: bool,
@@ -151,6 +155,9 @@ pub fn parse(args: &[String]) -> Cli {
         dump: args.dump.map(|x| x.into_os_string().into_string().unwrap()),
         ho2_capsule: args
             .ho2_capsule
+            .map(|x| x.into_os_string().into_string().unwrap()),
+        dump_ec_flash: args
+            .dump_ec_flash
             .map(|x| x.into_os_string().into_string().unwrap()),
         intrusion: args.intrusion,
         inputmodules: args.inputmodules,

--- a/framework_lib/src/commandline/clap_std.rs
+++ b/framework_lib/src/commandline/clap_std.rs
@@ -85,6 +85,14 @@ struct ClapCli {
     #[arg(long)]
     flash_ec: Option<std::path::PathBuf>,
 
+    /// Flash EC with new RO firmware from file
+    #[arg(long)]
+    flash_ro_ec: Option<std::path::PathBuf>,
+
+    /// Flash EC with new RW firmware from file
+    #[arg(long)]
+    flash_rw_ec: Option<std::path::PathBuf>,
+
     /// Show status of intrusion switch
     #[arg(long)]
     intrusion: bool,
@@ -169,6 +177,12 @@ pub fn parse(args: &[String]) -> Cli {
             .map(|x| x.into_os_string().into_string().unwrap()),
         flash_ec: args
             .flash_ec
+            .map(|x| x.into_os_string().into_string().unwrap()),
+        flash_ro_ec: args
+            .flash_ro_ec
+            .map(|x| x.into_os_string().into_string().unwrap()),
+        flash_rw_ec: args
+            .flash_rw_ec
             .map(|x| x.into_os_string().into_string().unwrap()),
         intrusion: args.intrusion,
         inputmodules: args.inputmodules,

--- a/framework_lib/src/commandline/clap_std.rs
+++ b/framework_lib/src/commandline/clap_std.rs
@@ -81,6 +81,10 @@ struct ClapCli {
     #[arg(long)]
     dump_ec_flash: Option<std::path::PathBuf>,
 
+    /// Flash EC with new firmware from file
+    #[arg(long)]
+    flash_ec: Option<std::path::PathBuf>,
+
     /// Show status of intrusion switch
     #[arg(long)]
     intrusion: bool,
@@ -158,6 +162,9 @@ pub fn parse(args: &[String]) -> Cli {
             .map(|x| x.into_os_string().into_string().unwrap()),
         dump_ec_flash: args
             .dump_ec_flash
+            .map(|x| x.into_os_string().into_string().unwrap()),
+        flash_ec: args
+            .flash_ec
             .map(|x| x.into_os_string().into_string().unwrap()),
         intrusion: args.intrusion,
         inputmodules: args.inputmodules,

--- a/framework_lib/src/commandline/clap_std.rs
+++ b/framework_lib/src/commandline/clap_std.rs
@@ -101,7 +101,7 @@ struct ClapCli {
     #[arg(long)]
     inputmodules: bool,
 
-    /// Show status of the input modules (Framework 16 only)
+    /// Set input deck power mode [possible values: auto, off, on] (Framework 16 only)
     #[arg(long)]
     input_deck_mode: Option<InputDeckModeArg>,
 

--- a/framework_lib/src/commandline/clap_std.rs
+++ b/framework_lib/src/commandline/clap_std.rs
@@ -119,6 +119,10 @@ struct ClapCli {
     #[arg(long)]
     reboot_ec: Option<RebootEcArg>,
 
+    /// Hash a file of arbitrary data
+    #[arg(long)]
+    hash: Option<std::path::PathBuf>,
+
     /// Select which driver is used. By default portio is used
     #[clap(value_enum)]
     #[arg(long)]
@@ -174,6 +178,7 @@ pub fn parse(args: &[String]) -> Cli {
         kblight: args.kblight,
         console: args.console,
         reboot_ec: args.reboot_ec,
+        hash: args.hash.map(|x| x.into_os_string().into_string().unwrap()),
         driver: args.driver,
         test: args.test,
         // TODO: Set help. Not very important because Clap handles this by itself

--- a/framework_lib/src/commandline/mod.rs
+++ b/framework_lib/src/commandline/mod.rs
@@ -757,7 +757,6 @@ fn print_help(updater: bool) {
 Usage: framework_tool [OPTIONS]
 
 Options:
-  -b                         Print output one screen at a time
   -v, --verbose...           More output per occurrence
   -q, --quiet...             Less output per occurrence
       --versions             List current firmware versions
@@ -788,6 +787,7 @@ Options:
       --hash <HASH>          Hash a file of arbitrary data
   -t, --test                 Run self-test to check if interaction with EC is possible
   -h, --help                 Print help information
+  -b                         Print output one screen at a time
     "#
     );
     if updater {

--- a/framework_lib/src/commandline/mod.rs
+++ b/framework_lib/src/commandline/mod.rs
@@ -771,17 +771,21 @@ Options:
       --pd-bin <PD_BIN>      Parse versions from PD firmware binary file
       --ec-bin <EC_BIN>      Parse versions from EC firmware binary file
       --capsule <CAPSULE>    Parse UEFI Capsule information from binary file
+      --dump <DUMP>          Dump extracted UX capsule bitmap image to a file
+      --ho2-capsule <HO2_CAPSULE>      Parse UEFI Capsule information from binary file
+      --dump-ec-flash <DUMP_EC_FLASH>  Dump EC flash contents
       --flash-ec <FLASH_EC>            Flash EC with new firmware from file
       --flash-ro-ec <FLASH_EC>         Flash EC with new firmware from file
       --flash-rw-ec <FLASH_EC>         Flash EC with new firmware from file
+      --reboot-ec            Control EC RO/RW jump [possible values: reboot, jump-ro, jump-rw, cancel-jump, disable-jump]
       --intrusion            Show status of intrusion switch
       --inputmodules         Show status of the input modules (Framework 16 only)
+      --input-deck-mode      Set input deck power mode [possible values: auto, off, on] (Framework 16 only)
       --charge-limit [<VAL>] Get or set battery charge limit (Percentage number as arg, e.g. '100')
       --fp-brightness [<VAL>]Get or set fingerprint LED brightness level [possible values: high, medium, low]
       --kblight [<KBLIGHT>]  Set keyboard backlight percentage or get, if no value provided
       --console <CONSOLE>    Get EC console, choose whether recent or to follow the output [possible values: recent, follow]
-      --reboot-ec            Control EC RO/RW jump [possible values: reboot, jump-ro, jump-rw, cancel-jump, disable-jump]
-      --dump-ec-flash <DUMP_EC_FLASH>  Dump EC flash contents
+      --hash <HASH>          Hash a file of arbitrary data
   -t, --test                 Run self-test to check if interaction with EC is possible
   -h, --help                 Print help information
     "#

--- a/framework_lib/src/commandline/uefi.rs
+++ b/framework_lib/src/commandline/uefi.rs
@@ -68,6 +68,7 @@ pub fn parse(args: &[String]) -> Cli {
         pd_bin: None,
         ec_bin: None,
         dump_ec_flash: None,
+        flash_ec: None,
         capsule: None,
         dump: None,
         ho2_capsule: None,
@@ -296,7 +297,15 @@ pub fn parse(args: &[String]) -> Cli {
             cli.dump_ec_flash = if args.len() > i + 1 {
                 Some(args[i + 1].clone())
             } else {
-                println!("--dump-ec-flash requires extra argument to denote input file");
+                println!("--dump-ec-flash requires extra argument to denote output file");
+                None
+            };
+            found_an_option = true;
+        } else if arg == "--flash-ec" {
+            cli.flash_ec = if args.len() > i + 1 {
+                Some(args[i + 1].clone())
+            } else {
+                println!("--flash_ec requires extra argument to denote input file");
                 None
             };
             found_an_option = true;

--- a/framework_lib/src/commandline/uefi.rs
+++ b/framework_lib/src/commandline/uefi.rs
@@ -80,6 +80,7 @@ pub fn parse(args: &[String]) -> Cli {
         kblight: None,
         console: None,
         reboot_ec: None,
+        hash: None,
         // This is the only driver that works on UEFI
         driver: Some(CrosEcDriverType::Portio),
         test: false,
@@ -306,6 +307,14 @@ pub fn parse(args: &[String]) -> Cli {
                 Some(args[i + 1].clone())
             } else {
                 println!("--flash_ec requires extra argument to denote input file");
+                None
+            };
+            found_an_option = true;
+        } else if arg == "--hash" {
+            cli.hash = if args.len() > i + 1 {
+                Some(args[i + 1].clone())
+            } else {
+                println!("--hash requires extra argument to denote input file");
                 None
             };
             found_an_option = true;

--- a/framework_lib/src/commandline/uefi.rs
+++ b/framework_lib/src/commandline/uefi.rs
@@ -67,6 +67,7 @@ pub fn parse(args: &[String]) -> Cli {
         privacy: false,
         pd_bin: None,
         ec_bin: None,
+        dump_ec_flash: None,
         capsule: None,
         dump: None,
         ho2_capsule: None,
@@ -288,6 +289,14 @@ pub fn parse(args: &[String]) -> Cli {
                 Some(args[i + 1].clone())
             } else {
                 println!("--ho2-capsule requires extra argument to denote input file");
+                None
+            };
+            found_an_option = true;
+        } else if arg == "--dump-ec-flash" {
+            cli.dump_ec_flash = if args.len() > i + 1 {
+                Some(args[i + 1].clone())
+            } else {
+                println!("--dump-ec-flash requires extra argument to denote input file");
                 None
             };
             found_an_option = true;

--- a/framework_lib/src/commandline/uefi.rs
+++ b/framework_lib/src/commandline/uefi.rs
@@ -69,6 +69,8 @@ pub fn parse(args: &[String]) -> Cli {
         ec_bin: None,
         dump_ec_flash: None,
         flash_ec: None,
+        flash_ro_ec: None,
+        flash_rw_ec: None,
         capsule: None,
         dump: None,
         ho2_capsule: None,
@@ -306,7 +308,23 @@ pub fn parse(args: &[String]) -> Cli {
             cli.flash_ec = if args.len() > i + 1 {
                 Some(args[i + 1].clone())
             } else {
-                println!("--flash_ec requires extra argument to denote input file");
+                println!("--flash-ec requires extra argument to denote input file");
+                None
+            };
+            found_an_option = true;
+        } else if arg == "--flash-ro-ec" {
+            cli.flash_ro_ec = if args.len() > i + 1 {
+                Some(args[i + 1].clone())
+            } else {
+                println!("--flash-ro-ec requires extra argument to denote input file");
+                None
+            };
+            found_an_option = true;
+        } else if arg == "--flash-rw-ec" {
+            cli.flash_rw_ec = if args.len() > i + 1 {
+                Some(args[i + 1].clone())
+            } else {
+                println!("--flash-rw-ec requires extra argument to denote input file");
                 None
             };
             found_an_option = true;

--- a/framework_lib/src/ec_binary.rs
+++ b/framework_lib/src/ec_binary.rs
@@ -182,6 +182,9 @@ pub fn read_ec_version(data: &[u8], ro: bool) -> Option<ImageVersionData> {
         EC_RW_VER_OFFSET_ZEPHYR
     };
 
+    if data.len() < offset + core::mem::size_of::<_ImageVersionData>() {
+        return None;
+    }
     let v: _ImageVersionData = unsafe { std::ptr::read(data[offset..].as_ptr() as *const _) };
     if v.cookie1 != CROS_EC_IMAGE_DATA_COOKIE1 {
         debug!("Failed to find Cookie 1. Found: {:X?}", { v.cookie1 });
@@ -191,6 +194,9 @@ pub fn read_ec_version(data: &[u8], ro: bool) -> Option<ImageVersionData> {
         return parse_ec_version(&v);
     }
 
+    if data.len() < offset_zephyr + core::mem::size_of::<_ImageVersionData>() {
+        return None;
+    }
     let v: _ImageVersionData =
         unsafe { std::ptr::read(data[offset_zephyr..].as_ptr() as *const _) };
     if v.cookie1 != CROS_EC_IMAGE_DATA_COOKIE1 {

--- a/framework_lib/src/ec_binary.rs
+++ b/framework_lib/src/ec_binary.rs
@@ -314,4 +314,26 @@ mod tests {
         assert_eq!(expected, read_ec_version(&data, false));
         assert_eq!(expected, read_ec_version(&data, true));
     }
+
+    #[test]
+    // Make sure it doesn't crash when reading an invalid binary
+    // Cargo.toml is significantly smaller than ec.bin
+    fn fails_cargo_toml() {
+        let mut ec_bin_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        ec_bin_path.push("Cargo.toml");
+        let data = fs::read(ec_bin_path).unwrap();
+        assert_eq!(None, read_ec_version(&data, false));
+        assert_eq!(None, read_ec_version(&data, true));
+    }
+
+    #[test]
+    // Make sure it doesn't crash when reading an invalid binary
+    // winux.bin is slightly larger than ec.bin
+    fn fails_winux() {
+        let mut ec_bin_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        ec_bin_path.push("test_bins/winux.bin");
+        let data = fs::read(ec_bin_path).unwrap();
+        assert_eq!(None, read_ec_version(&data, false));
+        assert_eq!(None, read_ec_version(&data, true));
+    }
 }

--- a/framework_lib/src/util.rs
+++ b/framework_lib/src/util.rs
@@ -170,3 +170,10 @@ pub fn assert_win_len<N: Num + std::fmt::Debug + Ord + NumCast + Copy>(left: N, 
     #[cfg(not(feature = "win_driver"))]
     assert_eq!(left, right);
 }
+
+pub fn print_buffer_short(buffer: &[u8]) {
+    for byte in buffer {
+        print!("{:02x}", byte);
+    }
+    println!();
+}


### PR DESCRIPTION
This is not official endorsement that you should flash EC firmware.
Use on your own risk.
Flashing RO firmware is disabled, this should prevent people from bricking their systems.
Framework systems don't use RW firmware at the moment.