### PR TITLE
Allow customizing platform if not matched

### DIFF
--- a/framework_lib/src/ccgx/device.rs
+++ b/framework_lib/src/ccgx/device.rs
@@ -1,4 +1,4 @@
-//! Communicate with CCGX (CCG5, CCG6) PD controllers
+//! Communicate with CCGX (CCG5, CCG6, CCG8) PD controllers
 //!
 //! The current implementation talks to them by tunneling I2C through EC host commands.
 
@@ -41,9 +41,12 @@ impl PdPort {
         let platform = &(*config).as_ref().unwrap().platform;
 
         match (platform, self) {
+            (Platform::GenericFramework((left, _), _, _), PdPort::Left01) => *left,
+            (Platform::GenericFramework((_, right), _, _), PdPort::Right23) => *right,
+            // Framework AMD Platforms (CCG8)
             (Platform::Framework13Amd | Platform::Framework16, PdPort::Left01) => 0x42,
             (Platform::Framework13Amd | Platform::Framework16, PdPort::Right23) => 0x40,
-            // Intel Platforms
+            // Framework Intel Platforms (CCG5 and CCG6)
             (_, PdPort::Left01) => 0x08,
             (_, PdPort::Right23) => 0x40,
         }
@@ -55,11 +58,11 @@ impl PdPort {
         let platform = &(*config).as_ref().unwrap().platform;
 
         Ok(match (platform, self) {
+            (Platform::GenericFramework(_, (left, _), _), PdPort::Left01) => *left,
+            (Platform::GenericFramework(_, (_, right), _), PdPort::Right23) => *right,
             (Platform::IntelGen11, _) => 6,
-            (Platform::IntelGen12, PdPort::Left01) => 6,
-            (Platform::IntelGen12, PdPort::Right23) => 7,
-            (Platform::IntelGen13, PdPort::Left01) => 6,
-            (Platform::IntelGen13, PdPort::Right23) => 7,
+            (Platform::IntelGen12 | Platform::IntelGen13, PdPort::Left01) => 6,
+            (Platform::IntelGen12 | Platform::IntelGen13, PdPort::Right23) => 7,
             (Platform::Framework13Amd | Platform::Framework16, PdPort::Left01) => 1,
             (Platform::Framework13Amd | Platform::Framework16, PdPort::Right23) => 2,
             // (_, _) => Err(EcError::DeviceError(format!(

--- a/framework_lib/src/chromium_ec/mod.rs
+++ b/framework_lib/src/chromium_ec/mod.rs
@@ -120,6 +120,11 @@ pub enum EcResponseStatus {
 }
 
 pub fn has_mec() -> bool {
+    let platform = smbios::get_platform().unwrap();
+    if let Platform::GenericFramework(_, _, has_mec) = platform {
+        return has_mec;
+    }
+
     !matches!(
         smbios::get_platform().unwrap(),
         Platform::Framework13Amd | Platform::Framework16


### PR DESCRIPTION
If the platform couldn't be matched by SMBIOS, now you can select the platform config manually on the commandline.
This is not usually needed, just for advanced users.

For example:

```
# Framework 13 Intel 11th Gen
framework_tool --test --driver portio --pd-addrs 8 64 --pd-ports 6 6 --has-mec true

# Framework 13 Intel 12th and 13th Gen
framework_tool --test --driver portio --pd-addrs 8 64 --pd-ports 6 7 --has-mec true

# Framework 13 AMD and Framework 16 AMD
framework_tool --test --driver portio --pd-addrs 66 64 --pd-ports 1 2 --has-mec false
```