### PR TITLE
framework_lib: Read ALS sensor

### DIFF
--- a/framework_lib/src/commandline/clap_std.rs
+++ b/framework_lib/src/commandline/clap_std.rs
@@ -33,6 +33,10 @@ struct ClapCli {
     #[arg(long)]
     thermal: bool,
 
+    /// Print sensor information (ALS, G-Sensor)
+    #[arg(long)]
+    sensors: bool,
+
     /// Show information about USB-C PD ports
     #[arg(long)]
     pdports: bool,
@@ -196,6 +200,7 @@ pub fn parse(args: &[String]) -> Cli {
         esrt: args.esrt,
         power: args.power,
         thermal: args.thermal,
+        sensors: args.sensors,
         pdports: args.pdports,
         pd_info: args.pd_info,
         dp_hdmi_info: args.dp_hdmi_info,

--- a/framework_lib/src/commandline/mod.rs
+++ b/framework_lib/src/commandline/mod.rs
@@ -122,6 +122,7 @@ pub struct Cli {
     pub esrt: bool,
     pub power: bool,
     pub thermal: bool,
+    pub sensors: bool,
     pub pdports: bool,
     pub privacy: bool,
     pub pd_info: bool,
@@ -606,6 +607,8 @@ pub fn run_with_args(args: &Cli, _allupdate: bool) -> i32 {
         power::get_and_print_power_info(&ec);
     } else if args.thermal {
         power::print_thermal(&ec);
+    } else if args.sensors {
+        power::print_sensors(&ec);
     } else if args.pdports {
         power::get_and_print_pd_info(&ec);
     } else if args.info {
@@ -784,7 +787,8 @@ Options:
       --version              Show tool version information (Add -vv for more detailed information)
       --esrt                 Display the UEFI ESRT table
       --power                Show current power status (battery and AC)
-      --thermal              Show current power status (battery and AC)
+      --thermal              Print thermal information (Temperatures and Fan speed)
+      --sensors              Print sensor information (ALS, G-Sensor)
       --pdports              Show information about USB-C PD ports
       --info                 Show info from SMBIOS (Only on UEFI)
       --pd-info              Show details about the PD controllers

--- a/framework_lib/src/commandline/uefi.rs
+++ b/framework_lib/src/commandline/uefi.rs
@@ -60,6 +60,7 @@ pub fn parse(args: &[String]) -> Cli {
         esrt: false,
         power: false,
         thermal: false,
+        sensors: false,
         pdports: false,
         pd_info: false,
         dp_hdmi_info: false,
@@ -130,6 +131,9 @@ pub fn parse(args: &[String]) -> Cli {
             found_an_option = true;
         } else if arg == "--thermal" {
             cli.thermal = true;
+            found_an_option = true;
+        } else if arg == "--sensors" {
+            cli.sensors = true;
             found_an_option = true;
         } else if arg == "--pdports" {
             cli.pdports = true;

--- a/framework_lib/src/power.rs
+++ b/framework_lib/src/power.rs
@@ -52,8 +52,8 @@ const EC_MEMMAP_BATT_MFGR: u16 = 0x60; // Battery Manufacturer String
 const EC_MEMMAP_BATT_MODEL: u16 = 0x68; // Battery Model Number String
 const EC_MEMMAP_BATT_SERIAL: u16 = 0x70; // Battery Serial Number String
 const EC_MEMMAP_BATT_TYPE: u16 = 0x78; // Battery Type String
-const _EC_MEMMAP_ALS: u16 = 0x80; // ALS readings in lux (2 X 16 bits)
-                                  // Unused 0x84 - 0x8f
+const EC_MEMMAP_ALS: u16 = 0x80; // ALS readings in lux (2 X 16 bits)
+                                 // Unused 0x84 - 0x8f
 const _EC_MEMMAP_ACC_STATUS: u16 = 0x90; // Accelerometer status (8 bits )
                                          // Unused 0x91
 const _EC_MEMMAP_ACC_DATA: u16 = 0x92; // Accelerometers data 0x92 - 0x9f
@@ -189,6 +189,13 @@ pub fn print_memmap_version_info(ec: &CrosEc) {
     let _battery_ver = ec.read_memory(EC_MEMMAP_BATTERY_VERSION, 2).unwrap(); /* Version of data in 0x40 - 0x7f */
     let _switches_ver = ec.read_memory(EC_MEMMAP_SWITCHES_VERSION, 2).unwrap(); /* Version of data in 0x30 - 0x33 */
     let _events_ver = ec.read_memory(EC_MEMMAP_EVENTS_VERSION, 2).unwrap();
+}
+
+pub fn print_sensors(ec: &CrosEc) {
+    let als = ec.read_memory(EC_MEMMAP_ALS, 0x04).unwrap();
+
+    let als_int = u32::from_le_bytes([als[0], als[1], als[2], als[3]]);
+    println!("ALS: {:>4} Lux", als_int);
 }
 
 pub fn print_thermal(ec: &CrosEc) {


### PR DESCRIPTION
Useful when there is no OS driver or when it's not working.
E.g. on FreeBSD or on early Intel systems with Linux kernel bug.