### PR TITLE
tgl: Fix PD controller version

### DIFF
--- a/framework_lib/src/ccgx/device.rs
+++ b/framework_lib/src/ccgx/device.rs
@@ -283,7 +283,9 @@ impl PdController {
         Ok((fw_mode, flash_row_size))
     }
     pub fn get_fw_versions(&self) -> EcResult<ControllerFirmwares> {
+        let (active_fw, _row_size) = self.get_device_info()?;
         Ok(ControllerFirmwares {
+            active_fw,
             bootloader: self.get_single_fw_ver(FwMode::BootLoader)?,
             backup_fw: self.get_single_fw_ver(FwMode::BackupFw)?,
             main_fw: self.get_single_fw_ver(FwMode::MainFw)?,

--- a/framework_lib/src/ccgx/mod.rs
+++ b/framework_lib/src/ccgx/mod.rs
@@ -7,7 +7,7 @@ use std::fmt;
 
 use crate::chromium_ec::{CrosEc, EcResult};
 
-use self::device::{PdController, PdPort};
+use self::device::{FwMode, PdController, PdPort};
 
 pub mod binary;
 pub mod device;
@@ -159,11 +159,7 @@ pub struct AppVersion {
 
 impl fmt::Display for AppVersion {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{}.{}.{:0>2} ({:?})",
-            self.major, self.minor, self.circuit, self.application
-        )
+        write!(f, "{}.{}.{:0>2}", self.major, self.minor, self.circuit)
     }
 }
 
@@ -197,6 +193,7 @@ pub struct ControllerVersion {
 
 #[derive(Debug, PartialEq)]
 pub struct ControllerFirmwares {
+    pub active_fw: FwMode,
     pub bootloader: ControllerVersion,
     pub backup_fw: ControllerVersion,
     pub main_fw: ControllerVersion,

--- a/framework_lib/src/power.rs
+++ b/framework_lib/src/power.rs
@@ -582,6 +582,7 @@ fn parse_pd_ver(data: &[u8; 8]) -> ControllerVersion {
 }
 
 // NOTE: Only works on ADL at the moment!
+// TODO: Not on TGL, need to check if RPL and later have it.
 pub fn read_pd_version(ec: &CrosEc) -> EcResult<MainPdVersions> {
     let info = EcRequestReadPdVersion {}.send_command(ec)?;
 


### PR DESCRIPTION
On TGL we modified the base version, not the app version. `-version` would show the incorrect version.
`--pd-info` shows both.

```
FS1:\> framework_tool.efi --versions
UEFI BIOS
  Version:        03.19
  Release Date:   05/29/2023
EC Firmware
  Build version:  "hx20_v0.0.1-f6d6b92 2023-05-26 00:03:59 runner@fv-az504-734"
  RO Version:     "hx20_v0.0.1-f6d6b92"
  RW Version:     "hx20_v0.0.1-f6d6b92"
  Current image:  RO
PD Controllers
  Right (01)
    Main:       3.4.0.2575 (Active)
    Backup:     3.4.0.2575
  Left  (23)
    Main:       3.4.0.2575 (Active)
    Backup:     3.4.0.2575
Retimers
  Left:           0xCF (207)
  Right:          0xCF (207)
```