### PR TITLE
Prettier --test command

### DIFF
--- a/framework_lib/src/ccgx/mod.rs
+++ b/framework_lib/src/ccgx/mod.rs
@@ -230,6 +230,7 @@ pub struct PdVersions {
 }
 
 /// Same as PdVersions but only the main FW
+#[derive(Debug)]
 pub struct MainPdVersions {
     pub controller01: ControllerVersion,
     pub controller23: ControllerVersion,

--- a/framework_lib/src/commandline/mod.rs
+++ b/framework_lib/src/commandline/mod.rs
@@ -1065,8 +1065,14 @@ fn selftest(ec: &CrosEc) -> Option<()> {
         return None;
     }
 
-    // Try to get PD versions through EC
-    power::read_pd_version(ec).ok()?;
+    println!("Reading PD Version from EC");
+    if let Err(err) = power::read_pd_version(ec) {
+        // TGL does not have this command, so we have to ignore it
+        if err != EcError::Response(EcResponseStatus::InvalidCommand) {
+            println!("Err: {:?}", err);
+            return None;
+        }
+    }
 
     let pd_01 = PdController::new(PdPort::Left01, ec.clone());
     let pd_23 = PdController::new(PdPort::Right23, ec.clone());

--- a/framework_lib/src/commandline/mod.rs
+++ b/framework_lib/src/commandline/mod.rs
@@ -35,6 +35,7 @@ use crate::chromium_ec;
 use crate::chromium_ec::commands::DeckStateMode;
 use crate::chromium_ec::commands::FpLedBrightnessLevel;
 use crate::chromium_ec::commands::RebootEcCmd;
+use crate::chromium_ec::EcResponseStatus;
 use crate::chromium_ec::{print_err, EcFlashType};
 use crate::chromium_ec::{EcError, EcResult};
 #[cfg(feature = "linux")]
@@ -1049,14 +1050,16 @@ fn selftest(ec: &CrosEc) -> Option<()> {
     println!("  Reading EC Build Version");
     print_err(ec.version_info())?;
 
-    println!("  Reading EC Flash by EC");
+    print!("  Reading EC Flash by EC");
     ec.flash_version()?;
+    println!(" - OK");
 
-    println!("  Reading EC Flash directly");
+    println!("  Reading EC Flash directly - See below");
     ec.test_ec_flash_read().ok()?;
 
-    println!("  Getting power info from EC");
+    print!("  Getting power info from EC");
     power::power_info(ec)?;
+    println!(" - OK");
 
     println!("  Getting AC info from EC");
     // All our laptops have at least 4 PD ports so far
@@ -1065,25 +1068,31 @@ fn selftest(ec: &CrosEc) -> Option<()> {
         return None;
     }
 
-    println!("Reading PD Version from EC");
+    print!("Reading PD Version from EC");
     if let Err(err) = power::read_pd_version(ec) {
         // TGL does not have this command, so we have to ignore it
         if err != EcError::Response(EcResponseStatus::InvalidCommand) {
+            println!();
             println!("Err: {:?}", err);
-            return None;
+        } else {
+            println!(" - Skipped");
         }
+    } else {
+        println!(" - OK");
     }
 
     let pd_01 = PdController::new(PdPort::Left01, ec.clone());
     let pd_23 = PdController::new(PdPort::Right23, ec.clone());
-    println!("  Getting PD01 info");
+    print!("  Getting PD01 info through I2C tunnel");
     print_err(pd_01.get_silicon_id())?;
     print_err(pd_01.get_device_info())?;
     print_err(pd_01.get_fw_versions())?;
-    println!("  Getting PD23 info");
+    println!(" - OK");
+    print!("  Getting PD23 info through I2C tunnel");
     print_err(pd_23.get_silicon_id())?;
     print_err(pd_23.get_device_info())?;
     print_err(pd_23.get_fw_versions())?;
+    println!(" - OK");
 
     Some(())
 }

--- a/framework_lib/src/power.rs
+++ b/framework_lib/src/power.rs
@@ -191,6 +191,7 @@ pub fn print_memmap_version_info(ec: &CrosEc) {
     let _events_ver = ec.read_memory(EC_MEMMAP_EVENTS_VERSION, 2).unwrap();
 }
 
+/// Not supported on TGL EC
 pub fn get_als_reading(ec: &CrosEc) -> Option<u32> {
     let als = ec.read_memory(EC_MEMMAP_ALS, 0x04)?;
     Some(u32::from_le_bytes([als[0], als[1], als[2], als[3]]))


### PR DESCRIPTION
Example on Intel Core Ultra:

```
> sudo ./framework_tool --test
Self-Test
  SMBIOS Platform:     IntelCoreUltra1
  Dump EC memory region
00000000: 7f82 7378 99ff ffff ffff ffff ffff ffff  .sx............
00000010: c410 ffff ffff ffff ffff ffff ffff ffff  ................
00000020: 4543 0102 0201 0103 0000 0000 0000 0000  EC..............
00000030: 0500 0000 0000 0000 0000 0000 0000 0000  ................
00000040: de44 0000 210a 0000 640b 0000 0b01 0000  .D..!...d.......
00000050: 4b0f 0000 783c 0000 a00f 0000 3b00 0000  K...x<......;...
00000060: 4e56 5400 0000 0000 4652 414e 4757 4100  NVT.....FRANGWA.
00000070: 3031 3130 0000 0000 4c49 4f4e 0000 0000  0110....LION....
00000080: 1300 0000 0000 0000 0000 0000 0000 0000  ................
00000090: 0000 0000 0000 0000 0000 0000 0000 0000  ................
000000a0: 0000 0000 0000 0000 0000 0000 0000 0000  ................
000000b0: 0000 0000 0000 0000 0000 0000 0000 0000  ................
000000c0: 0000 0000 0000 0000 0000 0000 0000 0000  ................
000000d0: 0000 0000 0000 0000 0000 0000 0000 0000  ................
000000e0: 0000 0000 0000 0000 0000 0000 0000 0000  ................
000000f0: 0000 0000 0000 0000 0000 0000 0000       ..............
  Checking EC memory mapped magic bytes
  Verified that Framework EC is present!
  Reading EC Build Version
  Reading EC Flash by EC - OK
  Reading EC Flash directly - See below
    Read first row of flash (RO FW)
      [5E, 4D, 3B, 2A, E1, 54, 0C, 03]
    Read first row of RW FW
      [30, 7E, 0C, 20, 61, 96, 09, 10]
    Read flash flags
      Valid flash flags
  Getting power info from EC - OK
  Getting AC info from EC
Reading PD Version from EC - OK
  Getting PD01 info through I2C tunnel - OK
  Getting PD23 info through I2C tunnel - OK
```