### PR TITLE
Allow decoding of SMBIOS Type 11 serialnumbers

### DIFF
--- a/framework_lib/src/commandline/clap_std.rs
+++ b/framework_lib/src/commandline/clap_std.rs
@@ -41,9 +41,13 @@ struct ClapCli {
     #[arg(long)]
     pdports: bool,
 
-    /// Show info from SMBIOS (Only on UEFI)
+    /// Show info from SMBIOS
     #[arg(long)]
     info: bool,
+
+    /// Show info about system serial numbers
+    #[arg(long)]
+    serialnums: bool,
 
     /// Show details about the PD controllers
     #[arg(long)]
@@ -255,6 +259,7 @@ pub fn parse(args: &[String]) -> Cli {
         // UEFI only - every command needs to implement a parameter to enable the pager
         paginate: false,
         info: args.info,
+        serialnums: args.serialnums,
         raw_command: vec![],
     }
 }

--- a/framework_lib/src/commandline/mod.rs
+++ b/framework_lib/src/commandline/mod.rs
@@ -154,6 +154,7 @@ pub struct Cli {
     pub has_mec: Option<bool>,
     pub help: bool,
     pub info: bool,
+    pub serialnums: bool,
     // UEFI only
     pub allupdate: bool,
     pub paginate: bool,
@@ -621,6 +622,8 @@ pub fn run_with_args(args: &Cli, _allupdate: bool) -> i32 {
         power::get_and_print_pd_info(&ec);
     } else if args.info {
         smbios_info();
+    } else if args.serialnums {
+        serialnum_info();
     } else if args.pd_info {
         print_pd_details(&ec);
     } else if args.dp_hdmi_info {
@@ -798,7 +801,8 @@ Options:
       --thermal              Print thermal information (Temperatures and Fan speed)
       --sensors              Print sensor information (ALS, G-Sensor)
       --pdports              Show information about USB-C PD ports
-      --info                 Show info from SMBIOS (Only on UEFI)
+      --info                 Show info from SMBIOS
+      --serialnums           Show info about system serial numbers
       --pd-info              Show details about the PD controllers
       --privacy              Show privacy switch statuses (camera and microphone)
       --pd-bin <PD_BIN>      Parse versions from PD firmware binary file
@@ -977,6 +981,19 @@ fn smbios_info() {
                 }
             }
             _ => {}
+        }
+    }
+}
+
+fn serialnum_info() {
+    let smbios = get_smbios();
+    if smbios.is_none() {
+        error!("Failed to find SMBIOS");
+        return;
+    }
+    for undefined_struct in smbios.unwrap().iter() {
+        if let DefinedStruct::OemStrings(data) = undefined_struct.defined_struct() {
+            smbios::dump_oem_strings(data.oem_strings());
         }
     }
 }

--- a/framework_lib/src/commandline/uefi.rs
+++ b/framework_lib/src/commandline/uefi.rs
@@ -94,6 +94,7 @@ pub fn parse(args: &[String]) -> Cli {
         help: false,
         allupdate: false,
         info: false,
+        serialnums: false,
         raw_command: vec![],
     };
 
@@ -143,6 +144,9 @@ pub fn parse(args: &[String]) -> Cli {
             found_an_option = true;
         } else if arg == "--info" {
             cli.info = true;
+            found_an_option = true;
+        } else if arg == "--serialnums" {
+            cli.serialnums = true;
             found_an_option = true;
         } else if arg == "--intrusion" {
             cli.intrusion = true;

--- a/framework_lib/src/lib.rs
+++ b/framework_lib/src/lib.rs
@@ -31,6 +31,7 @@ pub mod esrt;
 pub mod guid;
 mod os_specific;
 pub mod power;
+pub mod serialnum;
 pub mod smbios;
 #[cfg(feature = "uefi")]
 pub mod uefi;

--- a/framework_lib/src/serialnum.rs
+++ b/framework_lib/src/serialnum.rs
@@ -1,0 +1,101 @@
+use alloc::string::{String, ToString};
+use core::str::FromStr;
+
+#[derive(Debug)]
+pub struct FrameworkSerial {
+    // brand:  Always FR for Framework
+    // format: Always A
+    /// Three letter string
+    pub product: String,
+    /// Two letter string
+    pub oem: String,
+    /// Development state
+    pub cfg0: Cfg0,
+    /// Defines config of that specific product
+    pub cfg1: char,
+    pub year: u16,
+    pub week: u8,
+    pub day: WeekDay,
+    /// Four letter/digit string
+    pub part: String,
+}
+
+#[derive(Debug)]
+pub enum Cfg0 {
+    SKU = 0x00,
+    Poc1 = 0x01,
+    Proto1 = 0x02,
+    Proto2 = 0x03,
+    Evt1 = 0x04,
+    Evt2 = 0x05,
+    Reserved = 0x06,
+    Dvt1 = 0x07,
+    Dvt2 = 0x08,
+    Pvt = 0x09,
+    Mp = 0x0A,
+}
+
+#[derive(Debug)]
+pub enum WeekDay {
+    Monday = 1,
+    Tuesday,
+    Wednesday,
+    Thursday,
+    Friday,
+    Saturday,
+    Sunday,
+}
+
+impl FromStr for FrameworkSerial {
+    type Err = String;
+
+    // TODO: !!! PROPER ERROR HANDLING !!!
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let pattern =
+            r"FRA([A-Z]{3})([A-Z]{2})([0-9A-F])([0-9A-F])([0-9A-Z])([0-9]{2})([0-7])([0-9A-Z]{4})";
+        let re = regex::Regex::new(pattern).unwrap();
+
+        let caps = re.captures(s).ok_or("Invalid Serial".to_string())?;
+
+        let cfg0 = match caps.get(3).unwrap().as_str().chars().next().unwrap() {
+            '0' => Cfg0::SKU,
+            '1' => Cfg0::Poc1,
+            '2' => Cfg0::Proto1,
+            '3' => Cfg0::Proto2,
+            '4' => Cfg0::Evt1,
+            '5' => Cfg0::Evt2,
+            '6' => Cfg0::Reserved,
+            '7' => Cfg0::Dvt1,
+            '8' => Cfg0::Dvt2,
+            '9' => Cfg0::Pvt,
+            'A' => Cfg0::Mp,
+            _ => return Err("Invalid CFG0".to_string()),
+        };
+        let cfg1 = caps.get(4).unwrap().as_str().chars().next().unwrap();
+        let year = str::parse::<u16>(caps.get(5).unwrap().as_str()).unwrap();
+        let year = 2020 + year;
+        let week = str::parse::<u8>(caps.get(6).unwrap().as_str()).unwrap();
+        // TODO: Decode into date
+        let day = match str::parse::<u8>(caps.get(7).unwrap().as_str()).unwrap() {
+            1 => WeekDay::Monday,
+            2 => WeekDay::Tuesday,
+            3 => WeekDay::Wednesday,
+            4 => WeekDay::Thursday,
+            5 => WeekDay::Friday,
+            6 => WeekDay::Saturday,
+            7 => WeekDay::Sunday,
+            _ => return Err("Invalid Day".to_string()),
+        };
+
+        Ok(FrameworkSerial {
+            product: caps.get(1).unwrap().as_str().to_string(),
+            oem: caps.get(2).unwrap().as_str().to_string(),
+            cfg0,
+            cfg1,
+            year,
+            week,
+            day,
+            part: caps.get(2).unwrap().as_str().to_string(),
+        })
+    }
+}


### PR DESCRIPTION
They're the serialnumbers of what the system was originally assembled with in the factory.

TODO

- [ ] Cleanup code
- [ ] Make safer with fewer unwraps
- [ ] Custom command, not in info
- [ ] Make sure date is decoded correctly
- [ ] Make sure it works on Framework 16

```
> cargo build && sudo ./target/debug/framework_tool --serialnums                                                                                      
FRANMECP864201001H                                                                                                                            
  Mainboard                                                                                                                                   
  NME (Config 6) by CP, Dvt2 Phase (Monday, Week 20, 2024)                                                                                    
FRANPJCP8842010012                                                                                                                            
  Laptop                                                                                                                                      
  NPJ (Config 8) by CP, Dvt2 Phase (Monday, Week 20, 2024)                                                                                    
FRANJBCH8141750084                                                                                                                            
  Camera                                                                                                                                      
  NJB (Config 1) by CH, Dvt2 Phase (Friday, Week 17, 2024)                                                                                    
FRANJABQ814213002W                                                                                                                            
  Display                                                                                                                                     
  NJA (Config 1) by BQ, Dvt2 Phase (Wednesday, Week 21, 2024)                                                                                 
FRANGWATA1344300PG                                                                                                                            
  Battery                                                                                                                                     
  NGW (Config 1) by AT,   Mp Phase (Wednesday, Week 44, 2023)                                                                                 
FRANBTENA1414200X1                                                                                                                            
  Touchpad                                                                                                                                    
  NBT (Config 1) by EN,   Mp Phase (Tuesday, Week 14, 2024)                                                                                   
FRANBKENA1415100QM                                                                                                                            
  Keyboard                                                                                                                                    
  NBK (Config 1) by EN,   Mp Phase (Monday, Week 15, 2024)                                                                                    
FRANBFJYA1416603VX                                                                                                                            
  Fingerprint          (Only Pre-Built)                                                                                                       
  NBF (Config 1) by JY,   Mp Phase (Saturday, Week 16, 2024)                                                                                  
FRANBDCPA14181003C Unknown/Reserved                                                                                                           
FRANFJHAA1414500EA                                                                                                                            
  AudioDaughtercard                                                                                                                           
  NFJ (Config 1) by HA,   Mp Phase (Friday, Week 14, 2024)                                                                                    
```