### PR TITLE
framework_tool: Statically link CRT

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,6 +354,7 @@ name = "framework_tool"
 version = "0.1.0"
 dependencies = [
  "framework_lib",
+ "static_vcruntime",
 ]
 
 [[package]]
@@ -1114,6 +1115,12 @@ checksum = "7f6002a767bff9e83f8eeecf883ecb8011875a21ae8da43bffb817a57e78cc09"
 dependencies = [
  "lock_api",
 ]
+
+[[package]]
+name = "static_vcruntime"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "954e3e877803def9dc46075bf4060147c55cd70db97873077232eae0269dc89b"
 
 [[package]]
 name = "strsim"

--- a/framework_tool/Cargo.toml
+++ b/framework_tool/Cargo.toml
@@ -12,3 +12,6 @@ windows = ["framework_lib/windows"]
 [dependencies.framework_lib]
 path = "../framework_lib"
 default-features = false
+
+[build-dependencies]
+static_vcruntime = "2.0"

--- a/framework_tool/build.rs
+++ b/framework_tool/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    static_vcruntime::metabuild();
+}


### PR DESCRIPTION
Otherwise it won't run on freshly installed Windows systems because vcruntime is missing.

Must `cargo build --release` to get it. Debug builds won't have it linked statically.