### PR TITLE
framework_lib: Add ultra-low powerbutton brightness

### DIFF
--- a/framework_lib/src/chromium_ec/commands.rs
+++ b/framework_lib/src/chromium_ec/commands.rs
@@ -844,6 +844,7 @@ pub enum FpLedBrightnessLevel {
     High = 0,
     Medium = 1,
     Low = 2,
+    UltraLow = 3,
 }
 
 #[repr(C, packed)]

--- a/framework_lib/src/commandline/mod.rs
+++ b/framework_lib/src/commandline/mod.rs
@@ -93,6 +93,7 @@ pub enum FpBrightnessArg {
     High,
     Medium,
     Low,
+    UltraLow,
 }
 impl From<FpBrightnessArg> for FpLedBrightnessLevel {
     fn from(w: FpBrightnessArg) -> FpLedBrightnessLevel {
@@ -100,6 +101,7 @@ impl From<FpBrightnessArg> for FpLedBrightnessLevel {
             FpBrightnessArg::High => FpLedBrightnessLevel::High,
             FpBrightnessArg::Medium => FpLedBrightnessLevel::Medium,
             FpBrightnessArg::Low => FpLedBrightnessLevel::Low,
+            FpBrightnessArg::UltraLow => FpLedBrightnessLevel::UltraLow,
         }
     }
 }

--- a/framework_lib/src/commandline/uefi.rs
+++ b/framework_lib/src/commandline/uefi.rs
@@ -246,6 +246,8 @@ pub fn parse(args: &[String]) -> Cli {
                     Some(Some(FpBrightnessArg::Medium))
                 } else if fp_brightness_arg == "low" {
                     Some(Some(FpBrightnessArg::Low))
+                } else if fp_brightness_arg == "ultra-low" {
+                    Some(Some(FpBrightnessArg::UltraLow))
                 } else {
                     println!("Invalid value for --fp-brightness: {}", fp_brightness_arg);
                     None


### PR DESCRIPTION
Must also have EC support. Will be included in Framework 13 - AMD Ryzen AI 300 first and then gradually backported.
First step towards #37.