### PR TITLE
Add support for RGB command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,6 +176,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap-num"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "822c4000301ac390e65995c62207501e3ef800a1fc441df913a5e8e4dc374816"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "clap-verbosity-flag"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -383,6 +392,7 @@ version = "0.2.1"
 dependencies = [
  "built",
  "clap",
+ "clap-num",
  "clap-verbosity-flag",
  "env_logger",
  "guid_macros",

--- a/framework_lib/Cargo.toml
+++ b/framework_lib/Cargo.toml
@@ -18,7 +18,7 @@ cross_freebsd = ["unix", "freebsd_pio"]
 # Windows does not have the cros_ec driver nor raw port I/O access to userspace
 windows = ["std", "smbios", "dep:windows", "win_driver", "raw_pio", "hidapi", "rusb", "dep:wmi"]
 smbios = ["dep:smbios-lib"]
-std = ["dep:clap", "dep:clap-verbosity-flag", "dep:env_logger", "smbios-lib?/std"]
+std = ["dep:clap", "dep:clap-num", "dep:clap-verbosity-flag", "dep:env_logger", "smbios-lib?/std"]
 rusb = ["dep:rusb"]
 hidapi = ["dep:hidapi"]
 uefi = [
@@ -51,6 +51,7 @@ regex = { version = "1.11.1", default-features = false }
 redox_hwio = { git = "https://github.com/FrameworkComputer/rust-hwio", branch = "freebsd", default-features = false }
 libc = { version = "0.2.155", optional = true }
 clap = { version = "4.5", features = ["derive"], optional = true }
+clap-num = { version = "1.2.0", optional = true }
 clap-verbosity-flag = { version = "2.2.1", optional = true }
 nix = { version = "0.29.0", features = ["ioctl", "user"], optional = true }
 num = { version = "0.4", default-features = false }

--- a/framework_lib/src/chromium_ec/command.rs
+++ b/framework_lib/src/chromium_ec/command.rs
@@ -46,6 +46,8 @@ pub enum EcCommands {
     RebootEc = 0x00D2,
     /// Get information about PD controller power
     UsbPdPowerInfo = 0x0103,
+    RgbKbdSetColor = 0x013A,
+    RgbKbd = 0x013B,
 
     // Framework specific commands
     /// Configure the behavior of the flash notify

--- a/framework_lib/src/chromium_ec/command.rs
+++ b/framework_lib/src/chromium_ec/command.rs
@@ -34,18 +34,18 @@ pub enum EcCommands {
     PwmSetDuty = 0x0025,
     PwmGetDuty = 0x0026,
     SetTabletMode = 0x0031,
-    GpioGet = 0x93,
-    I2cPassthrough = 0x9e,
-    ConsoleSnapshot = 0x97,
-    ConsoleRead = 0x98,
+    GpioGet = 0x0093,
+    I2cPassthrough = 0x009e,
+    ConsoleSnapshot = 0x0097,
+    ConsoleRead = 0x0098,
     /// List the features supported by the firmware
-    GetFeatures = 0x0D,
+    GetFeatures = 0x000D,
     /// Force reboot, causes host reboot as well
-    Reboot = 0xD1,
+    Reboot = 0x00D1,
     /// Control EC boot
-    RebootEc = 0xD2,
+    RebootEc = 0x00D2,
     /// Get information about PD controller power
-    UsbPdPowerInfo = 0x103,
+    UsbPdPowerInfo = 0x0103,
 
     // Framework specific commands
     /// Configure the behavior of the flash notify

--- a/framework_lib/src/chromium_ec/commands.rs
+++ b/framework_lib/src/chromium_ec/commands.rs
@@ -518,6 +518,37 @@ impl EcRequest<EcResponseUsbPdPowerInfo> for EcRequestUsbPdPowerInfo {
     }
 }
 
+// TODO: Actually 128, but if we go above ~80 EC returns REQUEST_TRUNCATED
+// At least when I use the portio driver
+pub const EC_RGBKBD_MAX_KEY_COUNT: usize = 64;
+
+#[repr(C, packed)]
+#[derive(Default, Clone, Copy, Debug)]
+pub struct RgbS {
+    pub r: u8,
+    pub g: u8,
+    pub b: u8,
+}
+
+#[repr(C, packed)]
+pub struct EcRequestRgbKbdSetColor {
+    /// Specifies the starting key ID whose color is being changed
+    pub start_key: u8,
+    /// Specifies # of elements in color
+    pub length: u8,
+    /// RGB color data array of length up to MAX_KEY_COUNT
+    pub color: [RgbS; EC_RGBKBD_MAX_KEY_COUNT],
+}
+
+#[repr(C, packed)]
+pub struct EcResponseRgbKbdSetColor {}
+
+impl EcRequest<EcResponseRgbKbdSetColor> for EcRequestRgbKbdSetColor {
+    fn command_id() -> EcCommands {
+        EcCommands::RgbKbdSetColor
+    }
+}
+
 // --- Framework Specific commands ---
 
 #[repr(C, packed)]

--- a/framework_lib/src/chromium_ec/mod.rs
+++ b/framework_lib/src/chromium_ec/mod.rs
@@ -923,17 +923,19 @@ impl CrosEc {
     }
 
     pub fn rgbkbd_set_color(&self, start_key: u8, colors: Vec<RgbS>) -> EcResult<()> {
-        let mut request = EcRequestRgbKbdSetColor {
-            start_key,
-            length: colors.len() as u8,
-            color: [(); EC_RGBKBD_MAX_KEY_COUNT].map(|()| Default::default()),
-        };
+        for (chunk, colors) in colors.chunks(EC_RGBKBD_MAX_KEY_COUNT).enumerate() {
+            let mut request = EcRequestRgbKbdSetColor {
+                start_key: start_key + ((chunk * EC_RGBKBD_MAX_KEY_COUNT) as u8),
+                length: colors.len() as u8,
+                color: [(); EC_RGBKBD_MAX_KEY_COUNT].map(|()| Default::default()),
+            };
 
-        for (i, color) in colors.iter().enumerate() {
-            request.color[i] = *color;
+            for (i, color) in colors.iter().enumerate() {
+                request.color[i] = *color;
+            }
+
+            let _res = request.send_command(self)?;
         }
-
-        let _res = request.send_command(self)?;
         Ok(())
     }
 }

--- a/framework_lib/src/chromium_ec/mod.rs
+++ b/framework_lib/src/chromium_ec/mod.rs
@@ -921,6 +921,21 @@ impl CrosEc {
         let res = request.send_command(self)?;
         Ok(res.val == 1)
     }
+
+    pub fn rgbkbd_set_color(&self, start_key: u8, colors: Vec<RgbS>) -> EcResult<()> {
+        let mut request = EcRequestRgbKbdSetColor {
+            start_key,
+            length: colors.len() as u8,
+            color: [(); EC_RGBKBD_MAX_KEY_COUNT].map(|()| Default::default()),
+        };
+
+        for (i, color) in colors.iter().enumerate() {
+            request.color[i] = *color;
+        }
+
+        let _res = request.send_command(self)?;
+        Ok(())
+    }
 }
 
 #[cfg_attr(not(feature = "uefi"), derive(clap::ValueEnum))]

--- a/framework_lib/src/commandline/clap_std.rs
+++ b/framework_lib/src/commandline/clap_std.rs
@@ -3,6 +3,7 @@
 //! as well as on the UEFI shell tool.
 use clap::Parser;
 
+use crate::chromium_ec::commands::EC_RGBKBD_MAX_KEY_COUNT;
 use crate::chromium_ec::CrosEcDriverType;
 use crate::commandline::{
     Cli, ConsoleArg, FpBrightnessArg, HardwareDeviceType, InputDeckModeArg, RebootEcArg,
@@ -149,6 +150,13 @@ struct ClapCli {
     #[arg(long)]
     kblight: Option<Option<u8>>,
 
+    /// Set the color of <key> to <RGB>. Multiple colors for adjacent keys can be set at once.
+    /// <key> <RGB> [<RGB> ...]
+    /// Example: 0 0xFF000 0x00FF00 0x0000FF
+    #[clap(num_args = 2..EC_RGBKBD_MAX_KEY_COUNT)]
+    #[arg(long)]
+    rgbkbd: Vec<u64>,
+
     /// Set tablet mode override
     #[clap(value_enum)]
     #[arg(long)]
@@ -274,6 +282,7 @@ pub fn parse(args: &[String]) -> Cli {
         fp_led_level: args.fp_led_level,
         fp_brightness: args.fp_brightness,
         kblight: args.kblight,
+        rgbkbd: args.rgbkbd,
         tablet_mode: args.tablet_mode,
         console: args.console,
         reboot_ec: args.reboot_ec,

--- a/framework_lib/src/commandline/clap_std.rs
+++ b/framework_lib/src/commandline/clap_std.rs
@@ -2,6 +2,7 @@
 //! This way we can use it in the regular OS commandline tool on Linux and Windows,
 //! as well as on the UEFI shell tool.
 use clap::Parser;
+use clap_num::maybe_hex;
 
 use crate::chromium_ec::commands::EC_RGBKBD_MAX_KEY_COUNT;
 use crate::chromium_ec::CrosEcDriverType;
@@ -154,7 +155,7 @@ struct ClapCli {
     /// <key> <RGB> [<RGB> ...]
     /// Example: 0 0xFF000 0x00FF00 0x0000FF
     #[clap(num_args = 2..EC_RGBKBD_MAX_KEY_COUNT)]
-    #[arg(long)]
+    #[arg(long, value_parser=maybe_hex::<u64>)]
     rgbkbd: Vec<u64>,
 
     /// Set tablet mode override

--- a/framework_lib/src/commandline/clap_std.rs
+++ b/framework_lib/src/commandline/clap_std.rs
@@ -4,7 +4,6 @@
 use clap::Parser;
 use clap_num::maybe_hex;
 
-use crate::chromium_ec::commands::EC_RGBKBD_MAX_KEY_COUNT;
 use crate::chromium_ec::CrosEcDriverType;
 use crate::commandline::{
     Cli, ConsoleArg, FpBrightnessArg, HardwareDeviceType, InputDeckModeArg, RebootEcArg,
@@ -154,7 +153,7 @@ struct ClapCli {
     /// Set the color of <key> to <RGB>. Multiple colors for adjacent keys can be set at once.
     /// <key> <RGB> [<RGB> ...]
     /// Example: 0 0xFF000 0x00FF00 0x0000FF
-    #[clap(num_args = 2..EC_RGBKBD_MAX_KEY_COUNT)]
+    #[clap(num_args = 2..)]
     #[arg(long, value_parser=maybe_hex::<u64>)]
     rgbkbd: Vec<u64>,
 

--- a/framework_lib/src/commandline/uefi.rs
+++ b/framework_lib/src/commandline/uefi.rs
@@ -87,6 +87,7 @@ pub fn parse(args: &[String]) -> Cli {
         fp_led_level: None,
         fp_brightness: None,
         kblight: None,
+        rgbkbd: vec![],
         tablet_mode: None,
         console: None,
         reboot_ec: None,
@@ -216,6 +217,18 @@ pub fn parse(args: &[String]) -> Cli {
                 Some(None)
             };
             found_an_option = true;
+        } else if arg == "--rgbkbd" {
+            cli.rgbkbd = if args.len() > i + 2 {
+                let mut colors = Vec::<u64>::new();
+                for color_i in i + 1..args.len() {
+                    // TODO: Fail parsing instead of unwrap()
+                    colors.push(args[color_i].parse::<u64>().unwrap());
+                }
+                colors
+            } else {
+                println!("--rgbkbd requires at least 2 arguments, the start key and an RGB value");
+                vec![]
+            }
         } else if arg == "--tablet-mode" {
             cli.tablet_mode = if args.len() > i + 1 {
                 let tablet_mode_arg = &args[i + 1];

--- a/rgbkbd.py
+++ b/rgbkbd.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+# Example invocation in fish shell
+# cargo build && sudo ./target/debug/framework_tool \
+#   --driver portio --has-mec false --pd-ports 1 1 --pd-addrs 64 64 \
+#   (./rgbkbd.py | string split ' ')
+
+BRIGHTNESS = 1
+RED    = int(0xFF * BRIGHTNESS) << 16
+GREEN  = int(0xFF * BRIGHTNESS) << 8
+BLUE   = int(0xFF * BRIGHTNESS)
+CYAN   = GREEN + BLUE
+YELLOW = RED + GREEN
+PURPLE = BLUE + RED
+WHITE  = RED + GREEN + BLUE
+
+grid_4x4 = [
+  [ YELLOW,    RED,    RED,    RED, YELLOW ],
+  [    RED,  WHITE,  GREEN,  WHITE,    RED ],
+  [    RED,  GREEN,   BLUE,  GREEN,    RED ],
+  [    RED,  WHITE,  GREEN,  WHITE,    RED ],
+  [ YELLOW,    RED,    RED,    RED, YELLOW ],
+]
+
+fan_8leds = [[
+    # WHITE, CYAN, BLUE, GREEN, PURPLE, RED, YELLOW, WHITE
+    RED, RED, RED, RED,
+    GREEN, GREEN, GREEN, GREEN
+]]
+
+# colors = grid_4x4
+colors = fan_8leds
+
+print('--rgbkbd 0', end='')
+for row in colors:
+    for col in row:
+      print(' ', end='')
+      print(col, end='')


### PR DESCRIPTION
Yes, called rgbkbd because of the host command and to match ectool.
But we are actually planning to use it for the Framework Deskop's ARGB header (with fans, etc.)

For example:

```
# To set three LEDs to red, green, blue
sudo framework_tool --rgbkbd 0 0xFF0000 0x00FF00 0x0000FF

# To clear 8 LEDs
sudo framework_tool --rgbkbd 0 0 0 0 0 0 0 0 0

# Just turn the 3rd LED red
sudo framework_tool --rgbkbd 2 0xFF0000
```