### PR TITLE
fp-brightness: Add support for V1 host command

### DIFF
--- a/framework_lib/src/chromium_ec/commands.rs
+++ b/framework_lib/src/chromium_ec/commands.rs
@@ -845,6 +845,8 @@ pub enum FpLedBrightnessLevel {
     Medium = 1,
     Low = 2,
     UltraLow = 3,
+    /// Custom: Only get, never set
+    Custom = 0xFE,
     Auto = 0xFF,
 }
 

--- a/framework_lib/src/chromium_ec/commands.rs
+++ b/framework_lib/src/chromium_ec/commands.rs
@@ -845,6 +845,7 @@ pub enum FpLedBrightnessLevel {
     Medium = 1,
     Low = 2,
     UltraLow = 3,
+    Auto = 0xFF,
 }
 
 #[repr(C, packed)]

--- a/framework_lib/src/chromium_ec/commands.rs
+++ b/framework_lib/src/chromium_ec/commands.rs
@@ -849,7 +849,7 @@ pub enum FpLedBrightnessLevel {
 }
 
 #[repr(C, packed)]
-pub struct EcRequestFpLedLevelControl {
+pub struct EcRequestFpLedLevelControlV0 {
     /// See enum FpLedBrightnessLevel
     pub set_level: u8,
     /// Boolean. >1 to get the level
@@ -858,12 +858,42 @@ pub struct EcRequestFpLedLevelControl {
 
 #[repr(C, packed)]
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub struct EcResponseFpLedLevelControl {
+pub struct EcResponseFpLedLevelControlV0 {
+    /// Current brightness, 1-100%
+    pub percentage: u8,
+}
+
+impl EcRequest<EcResponseFpLedLevelControlV0> for EcRequestFpLedLevelControlV0 {
+    fn command_id() -> EcCommands {
+        EcCommands::FpLedLevelControl
+    }
+    fn command_version() -> u8 {
+        0
+    }
+}
+
+#[repr(C, packed)]
+pub struct EcRequestFpLedLevelControlV1 {
+    /// Percentage 1-100
+    pub set_percentage: u8,
+    /// Boolean. >1 to get the level
+    pub get_level: u8,
+}
+
+#[repr(C, packed)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct EcResponseFpLedLevelControlV1 {
+    /// Current brightness, 1-100%
+    pub percentage: u8,
+    /// Requested level. See enum FpLedBrightnessLevel
     pub level: u8,
 }
 
-impl EcRequest<EcResponseFpLedLevelControl> for EcRequestFpLedLevelControl {
+impl EcRequest<EcResponseFpLedLevelControlV1> for EcRequestFpLedLevelControlV1 {
     fn command_id() -> EcCommands {
         EcCommands::FpLedLevelControl
+    }
+    fn command_version() -> u8 {
+        1
     }
 }

--- a/framework_lib/src/chromium_ec/commands.rs
+++ b/framework_lib/src/chromium_ec/commands.rs
@@ -844,6 +844,7 @@ pub enum FpLedBrightnessLevel {
     High = 0,
     Medium = 1,
     Low = 2,
+    UltraLow = 3,
 }
 
 #[repr(C, packed)]

--- a/framework_lib/src/commandline/clap_std.rs
+++ b/framework_lib/src/commandline/clap_std.rs
@@ -137,9 +137,13 @@ struct ClapCli {
     #[arg(long)]
     get_gpio: Option<String>,
 
-    /// Get or set fingerprint LED brightness
+    /// Get or set fingerprint LED brightness level
     #[arg(long)]
-    fp_brightness: Option<Option<FpBrightnessArg>>,
+    fp_led_level: Option<Option<FpBrightnessArg>>,
+
+    /// Get or set fingerprint LED brightness percentage
+    #[arg(long)]
+    fp_brightness: Option<Option<u8>>,
 
     /// Set keyboard backlight percentage or get, if no value provided
     #[arg(long)]
@@ -267,6 +271,7 @@ pub fn parse(args: &[String]) -> Cli {
         input_deck_mode: args.input_deck_mode,
         charge_limit: args.charge_limit,
         get_gpio: args.get_gpio,
+        fp_led_level: args.fp_led_level,
         fp_brightness: args.fp_brightness,
         kblight: args.kblight,
         tablet_mode: args.tablet_mode,

--- a/framework_lib/src/commandline/mod.rs
+++ b/framework_lib/src/commandline/mod.rs
@@ -1364,8 +1364,13 @@ fn handle_fp_brightness(ec: &CrosEc, maybe_brightness: Option<FpBrightnessArg>) 
         ec.set_fp_led_level(brightness.into())?;
     }
 
-    let level = ec.get_fp_led_level()?;
-    println!("Fingerprint LED Brightness: {:?}%", level);
+    let (brightness, level) = ec.get_fp_led_level()?;
+    // TODO: Rename to power button
+    println!("Fingerprint LED Brightness");
+    if let Some(level) = level {
+        println!("  Requested:  {:?}", level);
+    }
+    println!("  Brightness: {}%", brightness);
 
     Ok(())
 }

--- a/framework_lib/src/commandline/mod.rs
+++ b/framework_lib/src/commandline/mod.rs
@@ -94,6 +94,7 @@ pub enum FpBrightnessArg {
     Medium,
     Low,
     UltraLow,
+    Auto,
 }
 impl From<FpBrightnessArg> for FpLedBrightnessLevel {
     fn from(w: FpBrightnessArg) -> FpLedBrightnessLevel {
@@ -102,6 +103,7 @@ impl From<FpBrightnessArg> for FpLedBrightnessLevel {
             FpBrightnessArg::Medium => FpLedBrightnessLevel::Medium,
             FpBrightnessArg::Low => FpLedBrightnessLevel::Low,
             FpBrightnessArg::UltraLow => FpLedBrightnessLevel::UltraLow,
+            FpBrightnessArg::Auto => FpLedBrightnessLevel::Auto,
         }
     }
 }

--- a/framework_lib/src/commandline/mod.rs
+++ b/framework_lib/src/commandline/mod.rs
@@ -163,7 +163,8 @@ pub struct Cli {
     pub input_deck_mode: Option<InputDeckModeArg>,
     pub charge_limit: Option<Option<u8>>,
     pub get_gpio: Option<String>,
-    pub fp_brightness: Option<Option<FpBrightnessArg>>,
+    pub fp_led_level: Option<Option<FpBrightnessArg>>,
+    pub fp_brightness: Option<Option<u8>>,
     pub kblight: Option<Option<u8>>,
     pub tablet_mode: Option<TabletModeArg>,
     pub console: Option<ConsoleArg>,
@@ -745,6 +746,8 @@ pub fn run_with_args(args: &Cli, _allupdate: bool) -> i32 {
         } else {
             println!("Not found");
         }
+    } else if let Some(maybe_led_level) = &args.fp_led_level {
+        print_err(handle_fp_led_level(&ec, *maybe_led_level));
     } else if let Some(maybe_brightness) = &args.fp_brightness {
         print_err(handle_fp_brightness(&ec, *maybe_brightness));
     } else if let Some(Some(kblight)) = args.kblight {
@@ -1013,7 +1016,8 @@ Options:
       --input-deck-mode      Set input deck power mode [possible values: auto, off, on] (Framework 16 only)
       --charge-limit [<VAL>] Get or set battery charge limit (Percentage number as arg, e.g. '100')
       --get-gpio <GET_GPIO>  Get GPIO value by name
-      --fp-brightness [<VAL>]Get or set fingerprint LED brightness level [possible values: high, medium, low]
+      --fp-led-level [<VAL>] Get or set fingerprint LED brightness level [possible values: high, medium, low]
+      --fp-brightness [<VAL>]Get or set fingerprint LED brightness percentage
       --kblight [<KBLIGHT>]  Set keyboard backlight percentage or get, if no value provided
       --console <CONSOLE>    Get EC console, choose whether recent or to follow the output [possible values: recent, follow]
       --hash <HASH>          Hash a file of arbitrary data
@@ -1359,9 +1363,25 @@ fn handle_charge_limit(ec: &CrosEc, maybe_limit: Option<u8>) -> EcResult<()> {
     Ok(())
 }
 
-fn handle_fp_brightness(ec: &CrosEc, maybe_brightness: Option<FpBrightnessArg>) -> EcResult<()> {
+fn handle_fp_led_level(ec: &CrosEc, maybe_led_level: Option<FpBrightnessArg>) -> EcResult<()> {
+    if let Some(led_level) = maybe_led_level {
+        ec.set_fp_led_level(led_level.into())?;
+    }
+
+    let (brightness, level) = ec.get_fp_led_level()?;
+    // TODO: Rename to power button
+    println!("Fingerprint LED Brightness");
+    if let Some(level) = level {
+        println!("  Requested:  {:?}", level);
+    }
+    println!("  Brightness: {}%", brightness);
+
+    Ok(())
+}
+
+fn handle_fp_brightness(ec: &CrosEc, maybe_brightness: Option<u8>) -> EcResult<()> {
     if let Some(brightness) = maybe_brightness {
-        ec.set_fp_led_level(brightness.into())?;
+        ec.set_fp_led_percentage(brightness)?;
     }
 
     let (brightness, level) = ec.get_fp_led_level()?;

--- a/framework_lib/src/commandline/mod.rs
+++ b/framework_lib/src/commandline/mod.rs
@@ -93,6 +93,7 @@ pub enum FpBrightnessArg {
     High,
     Medium,
     Low,
+    UltraLow,
 }
 impl From<FpBrightnessArg> for FpLedBrightnessLevel {
     fn from(w: FpBrightnessArg) -> FpLedBrightnessLevel {
@@ -100,6 +101,7 @@ impl From<FpBrightnessArg> for FpLedBrightnessLevel {
             FpBrightnessArg::High => FpLedBrightnessLevel::High,
             FpBrightnessArg::Medium => FpLedBrightnessLevel::Medium,
             FpBrightnessArg::Low => FpLedBrightnessLevel::Low,
+            FpBrightnessArg::UltraLow => FpLedBrightnessLevel::UltraLow,
         }
     }
 }

--- a/framework_lib/src/commandline/uefi.rs
+++ b/framework_lib/src/commandline/uefi.rs
@@ -246,6 +246,8 @@ pub fn parse(args: &[String]) -> Cli {
                     Some(Some(FpBrightnessArg::Medium))
                 } else if fp_brightness_arg == "low" {
                     Some(Some(FpBrightnessArg::Low))
+                } else if fp_brightness_arg == "ultra-low" {
+                    Some(Some(FpBrightnessArg::UltraLow))
                 } else {
                     println!("Invalid value for --fp-brightness: {}", fp_brightness_arg);
                     None

--- a/framework_lib/src/commandline/uefi.rs
+++ b/framework_lib/src/commandline/uefi.rs
@@ -84,6 +84,7 @@ pub fn parse(args: &[String]) -> Cli {
         input_deck_mode: None,
         charge_limit: None,
         get_gpio: None,
+        fp_led_level: None,
         fp_brightness: None,
         kblight: None,
         tablet_mode: None,
@@ -237,21 +238,41 @@ pub fn parse(args: &[String]) -> Cli {
                 None
             };
             found_an_option = true;
-        } else if arg == "--fp-brightness" {
-            cli.fp_brightness = if args.len() > i + 1 {
-                let fp_brightness_arg = &args[i + 1];
-                if fp_brightness_arg == "high" {
+        } else if arg == "--fp-led-level" {
+            cli.fp_led_level = if args.len() > i + 1 {
+                let fp_led_level_arg = &args[i + 1];
+                if fp_led_level_arg == "high" {
                     Some(Some(FpBrightnessArg::High))
-                } else if fp_brightness_arg == "medium" {
+                } else if fp_led_level_arg == "medium" {
                     Some(Some(FpBrightnessArg::Medium))
-                } else if fp_brightness_arg == "low" {
+                } else if fp_led_level_arg == "low" {
                     Some(Some(FpBrightnessArg::Low))
-                } else if fp_brightness_arg == "ultra-low" {
+                } else if fp_led_level_arg == "ultra-low" {
                     Some(Some(FpBrightnessArg::UltraLow))
-                } else if fp_brightness_arg == "auto" {
+                } else if fp_led_level_arg == "auto" {
                     Some(Some(FpBrightnessArg::Auto))
                 } else {
-                    println!("Invalid value for --fp-brightness: {}", fp_brightness_arg);
+                    println!("Invalid value for --fp-led-level: {}", fp_led_level_arg);
+                    None
+                }
+            } else {
+                Some(None)
+            };
+            found_an_option = true;
+        } else if arg == "--fp-brightness" {
+            cli.fp_brightness = if args.len() > i + 1 {
+                if let Ok(fp_brightness_arg) = args[i + 1].parse::<u8>() {
+                    if fp_brightness_arg == 0 || fp_brightness_arg > 100 {
+                        println!(
+                            "Invalid value for --fp-brightness: {}. Must be in the range of 1-100",
+                            fp_brightness_arg
+                        );
+                        None
+                    } else {
+                        Some(Some(fp_brightness_arg))
+                    }
+                } else {
+                    println!("Invalid value for --fp-brightness. Must be in the range of 1-100");
                     None
                 }
             } else {

--- a/framework_lib/src/commandline/uefi.rs
+++ b/framework_lib/src/commandline/uefi.rs
@@ -248,6 +248,8 @@ pub fn parse(args: &[String]) -> Cli {
                     Some(Some(FpBrightnessArg::Low))
                 } else if fp_brightness_arg == "ultra-low" {
                     Some(Some(FpBrightnessArg::UltraLow))
+                } else if fp_brightness_arg == "auto" {
+                    Some(Some(FpBrightnessArg::Auto))
                 } else {
                     println!("Invalid value for --fp-brightness: {}", fp_brightness_arg);
                     None


### PR DESCRIPTION
On new EC:

```
# Set different levels
> framework_tool.exe --fp-led-level medium
Fingerprint LED Brightness
  Requested:  Medium
  Brightness: 40%
> framework_tool.exe --fp-led-level high
Fingerprint LED Brightness
  Requested:  High
  Brightness: 55%

# Just get brightness 
> framework_tool.exe --fp-brightness
Fingerprint LED Brightness
  Requested:  High
  Brightness: 55%
# Set custom brightness
> framework_tool.exe --fp-brightness 32
Fingerprint LED Brightness
  Requested:  Custom
  Brightness: 32%

# Set new ultra-low level
> framework_tool.exe --fp-led-level ultra-low
Fingerprint LED Brightness
  Requested:  UltraLow
  Brightness: 8%
# Set new auto level
> framework_tool.exe --fp-led-level auto
Fingerprint LED Brightness
  Requested:  Auto
  Brightness: 55%

# Check which brightness auto results in (momentarily)
> framework_tool.exe --fp-brightness
Fingerprint LED Brightness
  Requested:  Auto
  Brightness: 8%
```

On old EC:

```
> sudo framework_tool --fp-brightness
Fingerprint LED Brightness
  Brightness: 8%

> sudo framework_tool --fp-brightness 42
[ERROR] EC Response Code: InvalidVersion

> sudo framework_tool --fp-led-level medium
Fingerprint LED Brightness
  Brightness: 40%

> sudo framework_tool --fp-led-level ultra-low
[ERROR] EC Response Code: InvalidParameter

> sudo framework_tool --fp-led-level auto
[ERROR] EC Response Code: InvalidParameter

> sudo framework_tool --fp-led-level 
Fingerprint LED Brightness
  Brightness: 8%
```