### PR TITLE
chromium: Add device_complete to diags

### DIFF
--- a/framework_lib/src/chromium_ec/commands.rs
+++ b/framework_lib/src/chromium_ec/commands.rs
@@ -772,6 +772,7 @@ pub struct EcRequestGetHwDiag {}
 pub struct EcResponseGetHwDiag {
     pub hw_diag: u32,
     pub bios_complete: u8,
+    pub device_complete: u8,
 }
 
 impl EcResponseGetHwDiag {


### PR DESCRIPTION
Was added to EC in
fwk: add device_complete
1753269e7e2c03c6ef667ae59fd594d2b753533f