### PR TITLE
camera: Print firmware version of camera

### DIFF
--- a/framework_lib/src/camera.rs
+++ b/framework_lib/src/camera.rs
@@ -1,0 +1,29 @@
+pub const FRAMEWORK_VID: u16 = 0x32AC;
+pub const FRAMEWORK13_16_2ND_GEN_PID: u16 = 0x001C;
+pub const FRAMEWORK12_PID: u16 = 0x001D;
+
+/// Get and print the firmware version of the camera
+pub fn check_camera_version() {
+    for dev in rusb::devices().unwrap().iter() {
+        let dev_descriptor = dev.device_descriptor().unwrap();
+        if dev_descriptor.vendor_id() != FRAMEWORK_VID
+            || (dev_descriptor.product_id() != FRAMEWORK13_16_2ND_GEN_PID
+                && dev_descriptor.product_id() != FRAMEWORK12_PID)
+        {
+            debug!(
+                "Skipping {:04X}:{:04X}",
+                dev_descriptor.vendor_id(),
+                dev_descriptor.product_id()
+            );
+            continue;
+        }
+        let handle = dev.open().unwrap();
+
+        let dev_descriptor = dev.device_descriptor().unwrap();
+        let i_product = dev_descriptor
+            .product_string_index()
+            .and_then(|x| handle.read_string_descriptor_ascii(x).ok());
+        println!("{}", i_product.unwrap_or_default());
+        println!("  Firmware Version: {}", dev_descriptor.device_version());
+    }
+}

--- a/framework_lib/src/commandline/mod.rs
+++ b/framework_lib/src/commandline/mod.rs
@@ -23,6 +23,8 @@ use std::io::prelude::*;
 #[cfg(feature = "rusb")]
 use crate::audio_card::check_synaptics_fw_version;
 use crate::built_info;
+#[cfg(feature = "rusb")]
+use crate::camera::check_camera_version;
 use crate::capsule;
 use crate::capsule_content::{
     find_bios_version, find_ec_in_bios_cap, find_pd_in_bios_cap, find_retimer_version,
@@ -470,6 +472,8 @@ fn print_versions(ec: &CrosEc) {
             println!("  Unknown");
         }
     }
+    #[cfg(feature = "rusb")]
+    check_camera_version();
 }
 
 fn print_esrt() {

--- a/framework_lib/src/lib.rs
+++ b/framework_lib/src/lib.rs
@@ -14,6 +14,8 @@ extern crate log;
 
 #[cfg(feature = "rusb")]
 pub mod audio_card;
+#[cfg(feature = "rusb")]
+pub mod camera;
 
 #[cfg(feature = "uefi")]
 #[macro_use]


### PR DESCRIPTION
Example on Framework 12:

```
> framework_tool --versions
[...]
Framework Laptop 12 Webcam Module
  Firmware Version: 0.1.6
```

Example on Framework 13:

```
> framework_tool --versions
[...]
Laptop Webcam Module (2nd Gen)
  Firmware Version: 1.1.1
```

Tested on:

- [x] Linux
- [x] Windows
- [x] FreeBSD
- [ ] UEFI Shell (Not working)