### PR TITLE
windows: Upload release binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,20 +91,24 @@ jobs:
     - name: Setup Rust toolchain
       run: rustup show
 
+    # Build debug library first to fail fast
     - name: Build library (Windows)
       run: cargo build -p framework_lib --no-default-features --features "windows"
 
     - name: Build Windows tool
-      run: cargo build -p framework_tool --no-default-features --features "windows"
+      run: |
+        cargo build -p framework_tool --no-default-features --features "windows"
+        cargo build -p framework_tool --no-default-features --features "windows" --release
 
     - name: Check if Windows tool can start
-      run: cargo run --no-default-features --features "windows" -- --help
+      run: cargo run --no-default-features --features "windows" -- --help --release
 
+    # Upload release build so that vcruntime is statically linked
     - name: Upload Windows App
       uses: actions/upload-artifact@v4
       with:
         name: framework_tool.exe
-        path: target/debug/framework_tool.exe
+        path: target/release/framework_tool.exe
 
 
   test:

--- a/framework_lib/src/chromium_ec/mod.rs
+++ b/framework_lib/src/chromium_ec/mod.rs
@@ -916,7 +916,7 @@ impl CrosEc {
         let mut request = EcRequestGpioGetV0 { name: [0; MAX_LEN] };
 
         let end = MAX_LEN.min(name.len());
-        request.name[..end].copy_from_slice(name[..end].as_bytes());
+        request.name[..end].copy_from_slice(&name.as_bytes()[..end]);
 
         let res = request.send_command(self)?;
         Ok(res.val == 1)

--- a/framework_tool/Cargo.toml
+++ b/framework_tool/Cargo.toml
@@ -14,4 +14,5 @@ path = "../framework_lib"
 default-features = false
 
 [build-dependencies]
+# Note: Only takes effect in release builds
 static_vcruntime = "2.0"


### PR DESCRIPTION
So that the vcruntime DLL is built in and runs on freshly installed windows systems.