### PR TITLE
windows: Don't panic if driver not installed

### DIFF
--- a/framework_lib/src/commandline/mod.rs
+++ b/framework_lib/src/commandline/mod.rs
@@ -1111,7 +1111,8 @@ fn selftest(ec: &CrosEc) -> Option<()> {
     if let Some(mem) = ec.dump_mem_region() {
         util::print_multiline_buffer(&mem, 0);
     } else {
-        println!("    Failed to read EC memory region")
+        println!("    Failed to read EC memory region");
+        return None;
     }
 
     println!("  Checking EC memory mapped magic bytes");


### PR DESCRIPTION
Trying it out without running as admin to cause it to fail accessing the driver.

```
# After
> cargo run --no-default-features --features "windows" -p framework_tool -- --test
Self-Test
  SMBIOS Platform:     Framework13AmdAi300
  Dump EC memory region
[ERROR] Failed to find Windows driver. Error { code: HRESULT(0x80070005), message: "Access is denied." }
[ERROR] Failed to communicate with EC. Reason: "Failed to initialize"
    Failed to read EC memory region
FAILED!!
Error: "Fail"
error: process didn't exit successfully: `target\debug\framework_tool.exe --test` (exit code: 1)

# Before
> cargo run --no-default-features --features "windows" -p framework_tool -- --test
Self-Test
  SMBIOS Platform:     Framework13AmdAi300
  Dump EC memory region
thread 'main' panicked at framework_lib\src\chromium_ec\windows.rs:46:14:
called `Result::unwrap()` on an `Err` value: Error { code: HRESULT(0x80070005), message: "Access is denied." }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
error: process didn't exit successfully: `target\debug\framework_tool.exe --test` (exit code: 101)
```