### PR TITLE
Don't show retimer as unknown if none present

### DIFF
--- a/framework_lib/src/commandline/mod.rs
+++ b/framework_lib/src/commandline/mod.rs
@@ -481,7 +481,9 @@ fn print_versions(ec: &CrosEc) {
     let _ignore_err = print_touchpad_fw_ver();
 
     #[cfg(feature = "hidapi")]
-    let _ignore_err = touchscreen::print_fw_ver();
+    if let Some(Platform::Framework12IntelGen13) = smbios::get_platform() {
+        let _ignore_err = touchscreen::print_fw_ver();
+    }
 }
 
 fn print_esrt() {


### PR DESCRIPTION
On platforms that don't have an updateable retimer, we don't need to show anything. Currently it would show as "Unknown".