### PR TITLE
Add --expansion-bay command to print info

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -64,3 +64,15 @@ ALS:   76 Lux
   APU:          42 C
   Fan Speed:       0 RPM
 ```
+
+## Check expansion bay (Framework 16)
+
+```
+> sudo framework_tool --expansion-bay
+Expansion Bay
+  Enabled:       true
+  Has fault:     false
+  Hatch closed:  true
+  Board:         DualInterposer
+  Serial Number: FRAXXXXXXXXXXXXXXX
+```

--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Options:
       --inputmodules                Show status of the input modules (Framework 16 only)
       --input-deck-mode <INPUT_DECK_MODE>
           Set input deck power mode [possible values: auto, off, on] (Framework 16 only) [possible values: auto, off, on]
+      --expansion-bay               Show status of the expansion bay (Framework 16 only)
       --charge-limit [<CHARGE_LIMIT>]
           Get or set max charge limit
       --get-gpio <GET_GPIO>

--- a/framework_lib/src/chromium_ec/mod.rs
+++ b/framework_lib/src/chromium_ec/mod.rs
@@ -817,6 +817,27 @@ impl CrosEc {
         res
     }
 
+    pub fn check_bay_status(&self) -> EcResult<()> {
+        println!("Expansion Bay");
+
+        let info = EcRequestExpansionBayStatus {}.send_command(self)?;
+        println!("  Enabled:       {}", info.module_enabled());
+        println!("  Has fault:     {}", info.module_fault());
+        println!("  Hatch closed:  {}", info.hatch_switch_closed());
+        match info.expansion_bay_board() {
+            Ok(board) => println!("  Board:         {:?}", board),
+            Err(err) => println!("  Board:         {:?}", err),
+        }
+
+        if let Ok(sn) = self.get_gpu_serial() {
+            println!("  Serial Number: {}", sn);
+        } else {
+            println!("  Serial Number: Unknown");
+        }
+
+        Ok(())
+    }
+
     /// Get the GPU Serial
     ///
     pub fn get_gpu_serial(&self) -> EcResult<String> {

--- a/framework_lib/src/commandline/clap_std.rs
+++ b/framework_lib/src/commandline/clap_std.rs
@@ -147,6 +147,10 @@ struct ClapCli {
     #[arg(long)]
     input_deck_mode: Option<InputDeckModeArg>,
 
+    /// Show status of the expansion bay (Framework 16 only)
+    #[arg(long)]
+    expansion_bay: bool,
+
     /// Get or set max charge limit
     #[arg(long)]
     charge_limit: Option<Option<u8>>,
@@ -352,6 +356,7 @@ pub fn parse(args: &[String]) -> Cli {
         intrusion: args.intrusion,
         inputmodules: args.inputmodules,
         input_deck_mode: args.input_deck_mode,
+        expansion_bay: args.expansion_bay,
         charge_limit: args.charge_limit,
         get_gpio: args.get_gpio,
         fp_led_level: args.fp_led_level,

--- a/framework_lib/src/commandline/mod.rs
+++ b/framework_lib/src/commandline/mod.rs
@@ -763,11 +763,8 @@ pub fn run_with_args(args: &Cli, _allupdate: bool) -> i32 {
         println!("Set mode to: {:?}", mode);
         ec.set_input_deck_mode((*mode).into()).unwrap();
     } else if args.expansion_bay {
-        println!("Expansion Bay");
-        if let Ok(sn) = ec.get_gpu_serial() {
-            println!("  Serial Number: {}", sn);
-        } else {
-            println!("  Serial Number: Unknown");
+        if let Err(err) = ec.check_bay_status() {
+            error!("{:?}", err);
         }
     } else if let Some(maybe_limit) = args.charge_limit {
         print_err(handle_charge_limit(&ec, maybe_limit));

--- a/framework_lib/src/commandline/mod.rs
+++ b/framework_lib/src/commandline/mod.rs
@@ -173,6 +173,7 @@ pub struct Cli {
     pub intrusion: bool,
     pub inputmodules: bool,
     pub input_deck_mode: Option<InputDeckModeArg>,
+    pub expansion_bay: bool,
     pub charge_limit: Option<Option<u8>>,
     pub get_gpio: Option<String>,
     pub fp_led_level: Option<Option<FpBrightnessArg>>,
@@ -761,6 +762,13 @@ pub fn run_with_args(args: &Cli, _allupdate: bool) -> i32 {
     } else if let Some(mode) = &args.input_deck_mode {
         println!("Set mode to: {:?}", mode);
         ec.set_input_deck_mode((*mode).into()).unwrap();
+    } else if args.expansion_bay {
+        println!("Expansion Bay");
+        if let Ok(sn) = ec.get_gpu_serial() {
+            println!("  Serial Number: {}", sn);
+        } else {
+            println!("  Serial Number: Unknown");
+        }
     } else if let Some(maybe_limit) = args.charge_limit {
         print_err(handle_charge_limit(&ec, maybe_limit));
     } else if let Some(gpio_name) = &args.get_gpio {
@@ -1080,6 +1088,7 @@ Options:
       --intrusion            Show status of intrusion switch
       --inputmodules         Show status of the input modules (Framework 16 only)
       --input-deck-mode      Set input deck power mode [possible values: auto, off, on] (Framework 16 only)
+      --expansion-bay        Show status of the expansion bay (Framework 16 only)
       --charge-limit [<VAL>] Get or set battery charge limit (Percentage number as arg, e.g. '100')
       --get-gpio <GET_GPIO>  Get GPIO value by name
       --fp-led-level [<VAL>] Get or set fingerprint LED brightness level [possible values: high, medium, low]

--- a/framework_lib/src/commandline/uefi.rs
+++ b/framework_lib/src/commandline/uefi.rs
@@ -86,6 +86,7 @@ pub fn parse(args: &[String]) -> Cli {
         intrusion: false,
         inputmodules: false,
         input_deck_mode: None,
+        expansion_bay: false,
         charge_limit: None,
         get_gpio: None,
         fp_led_level: None,
@@ -246,6 +247,9 @@ pub fn parse(args: &[String]) -> Cli {
                 );
                 None
             };
+            found_an_option = true;
+        } else if arg == "--expansion-bay" {
+            cli.expansion_bay = true;
             found_an_option = true;
         } else if arg == "--charge-limit" {
             cli.charge_limit = if args.len() > i + 1 {


### PR DESCRIPTION
```
> framework_tool.exe --expansion-bay
Expansion Bay
  Enabled:       true
  Has fault:     false
  Hatch closed:  true
  Board:         DualInterposer
  Serial Number: FRAXXXXXXXXXXXXXXX
```