### PR TITLE
--input-deck: Print Framework12 and Framework 13 input deck status

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Options:
       --dump <DUMP>                 Dump extracted UX capsule bitmap image to a file
       --h2o-capsule <H2O_CAPSULE>   Parse UEFI Capsule information from binary file
       --intrusion                   Show status of intrusion switch
-      --inputmodules                Show status of the input modules (Framework 16 only)
+      --inputdeck                   Show status of the input deck
       --input-deck-mode <INPUT_DECK_MODE>
           Set input deck power mode [possible values: auto, off, on] (Framework 16 only) [possible values: auto, off, on]
       --expansion-bay               Show status of the expansion bay (Framework 16 only)

--- a/completions/bash/framework_tool
+++ b/completions/bash/framework_tool
@@ -35,7 +35,7 @@ _framework_tool() {
         "--flash-rw-ec"
         "--intrusion"
         "--inputdeck"
-        "--input-deck-mode"
+        "--inputdeck-mode"
         "--charge-limit"
         "--get-gpio"
 	"--fp-led-level"
@@ -56,7 +56,7 @@ _framework_tool() {
     )
 
     local devices=("bios" "ec" "pd0" "pd1" "rtm01" "rtm23" "ac-left" "ac-right")
-    local input_deck_modes=("auto" "off" "on")
+    local inputdeck_modes=("auto" "off" "on")
     local console_modes=("recent" "follow")
     local drivers=("portio" "cros-ec" "windows")
     local has_mec_options=("true" "false")
@@ -71,8 +71,8 @@ _framework_tool() {
         COMPREPLY=( $(compgen -W "${options[*]}" -- "$current_word") )
     elif [[ $prev_word == "--device" ]]; then
         COMPREPLY=( $(compgen -W "${devices[*]}" -- "$current_word") )
-    elif [[ $prev_word == "--input-deck-mode" ]]; then
-        COMPREPLY=( $(compgen -W "${input_deck_modes[*]}" -- "$current_word") )
+    elif [[ $prev_word == "--inputdeck-mode" ]]; then
+        COMPREPLY=( $(compgen -W "${inputdeck_modes[*]}" -- "$current_word") )
     elif [[ $prev_word == "--console" ]]; then
         COMPREPLY=( $(compgen -W "${console_modes[*]}" -- "$current_word") )
     elif [[ $prev_word == "--driver" ]]; then

--- a/completions/bash/framework_tool
+++ b/completions/bash/framework_tool
@@ -34,7 +34,7 @@ _framework_tool() {
         "--flash-ro-ec"
         "--flash-rw-ec"
         "--intrusion"
-        "--inputmodules"
+        "--inputdeck"
         "--input-deck-mode"
         "--charge-limit"
         "--get-gpio"

--- a/completions/zsh/_framework_tool
+++ b/completions/zsh/_framework_tool
@@ -33,7 +33,7 @@ options=(
   '--flash-rw-ec[Flash EC with new RW firmware from file]:flash_rw_ec'
   '--intrusion[Show status of intrusion switch]'
   '--inputdeck[Show status of the input deck]'
-  '--input-deck-mode[Set input deck power mode]:input_deck_mode:(auto off on)'
+  '--inputdeck-mode[Set input deck power mode]:inputdeck_mode:(auto off on)'
   '--charge-limit[Get or set max charge limit]:charge_limit'
   '--get-gpio[Get GPIO value by name]:get_gpio'
   '--fp-led-level-gpio[Get or set fingerprint LED brightness level]:fp_led_level:(high medium low ultra-low auto)'

--- a/completions/zsh/_framework_tool
+++ b/completions/zsh/_framework_tool
@@ -32,7 +32,7 @@ options=(
   '--flash-ro-ec[Flash EC with new RO firmware from file]:flash_ro_ec'
   '--flash-rw-ec[Flash EC with new RW firmware from file]:flash_rw_ec'
   '--intrusion[Show status of intrusion switch]'
-  '--inputmodules[Show status of the input modules (Framework 16 only)]'
+  '--inputdeck[Show status of the input deck]'
   '--input-deck-mode[Set input deck power mode]:input_deck_mode:(auto off on)'
   '--charge-limit[Get or set max charge limit]:charge_limit'
   '--get-gpio[Get GPIO value by name]:get_gpio'

--- a/framework_lib/src/chromium_ec/mod.rs
+++ b/framework_lib/src/chromium_ec/mod.rs
@@ -394,6 +394,19 @@ impl CrosEc {
         Ok(InputDeckStatus::from(status))
     }
 
+    pub fn print_fw16_inputdeck_status(&self) -> EcResult<()> {
+        let status = self.get_input_deck_status()?;
+        println!("Input Deck State: {:?}", status.state);
+        println!("Touchpad present: {:?}", status.touchpad_present);
+        println!("Positions:");
+        println!("  Pos 0: {:?}", status.top_row.pos0);
+        println!("  Pos 1: {:?}", status.top_row.pos1);
+        println!("  Pos 2: {:?}", status.top_row.pos2);
+        println!("  Pos 3: {:?}", status.top_row.pos3);
+        println!("  Pos 4: {:?}", status.top_row.pos4);
+        Ok(())
+    }
+
     pub fn set_input_deck_mode(&self, mode: DeckStateMode) -> EcResult<InputDeckStatus> {
         let status = EcRequestDeckState { mode }.send_command(self)?;
 

--- a/framework_lib/src/chromium_ec/mod.rs
+++ b/framework_lib/src/chromium_ec/mod.rs
@@ -435,6 +435,27 @@ impl CrosEc {
         Ok(InputDeckStatus::from(status))
     }
 
+    pub fn print_fw12_inputdeck_status(&self) -> EcResult<()> {
+        let intrusion = self.get_intrusion_status()?;
+        let pwrbtn = self.read_board_id(Framework12Adc::PowerButtonBoard)?;
+        let audio = self.read_board_id(Framework12Adc::AudioBoard)?;
+        let tp = self.read_board_id(Framework12Adc::Touchpad)?;
+
+        let is_present = |p| if p { "Present" } else { "Missing" };
+
+        println!("Input Deck");
+        println!("  Chassis Open:        {}", intrusion.currently_open);
+        println!("  Power Button Board:  {}", is_present(pwrbtn.is_some()));
+        println!("  Audio Daughterboard: {}", is_present(audio.is_some()));
+        println!("  Touchpad:            {}", is_present(tp.is_some()));
+
+        Ok(())
+    }
+
+    pub fn print_fw13_inputdeck_status(&self) -> EcResult<()> {
+        Ok(())
+    }
+
     pub fn print_fw16_inputdeck_status(&self) -> EcResult<()> {
         let status = self.get_input_deck_status()?;
         println!("Input Deck State: {:?}", status.state);

--- a/framework_lib/src/chromium_ec/mod.rs
+++ b/framework_lib/src/chromium_ec/mod.rs
@@ -123,12 +123,47 @@ pub enum EcResponseStatus {
 #[repr(u8)]
 #[derive(Copy, Clone, Debug)]
 pub enum Framework12Adc {
-    MainboardBoard,
-    PowerButtonBoard,
+    MainboardBoardId,
+    PowerButtonBoardId,
     Psys,
     AdapterCurrent,
-    Touchpad,
-    AudioBoard,
+    TouchpadBoardId,
+    AudioBoardId,
+}
+
+#[repr(u8)]
+#[derive(Copy, Clone, Debug)]
+pub enum FrameworkHx20Hx30Adc {
+    AdapterCurrent,
+    Psys,
+    BattTemp,
+    TouchpadBoardId,
+    MainboardBoardId,
+    AudioBoardId,
+}
+
+/// So far on all Nuvoton/Zephyr EC based platforms
+/// Until at least Framework 13 AMD Ryzen AI 300
+#[repr(u8)]
+#[derive(Copy, Clone, Debug)]
+pub enum Framework13Adc {
+    MainboardBoardId,
+    Psys,
+    AdapterCurrent,
+    TouchpadBoardId,
+    AudioBoardId,
+    BattTemp,
+}
+
+#[repr(u8)]
+#[derive(Copy, Clone, Debug)]
+pub enum Framework16Adc {
+    MainboardBoardId,
+    HubBoardId,
+    GpuBoardId0,
+    GpuBoardId1,
+    AdapterCurrent,
+    Psys,
 }
 
 /*
@@ -437,9 +472,9 @@ impl CrosEc {
 
     pub fn print_fw12_inputdeck_status(&self) -> EcResult<()> {
         let intrusion = self.get_intrusion_status()?;
-        let pwrbtn = self.read_board_id(Framework12Adc::PowerButtonBoard)?;
-        let audio = self.read_board_id(Framework12Adc::AudioBoard)?;
-        let tp = self.read_board_id(Framework12Adc::Touchpad)?;
+        let pwrbtn = self.read_board_id(Framework12Adc::PowerButtonBoardId as u8)?;
+        let audio = self.read_board_id(Framework12Adc::AudioBoardId as u8)?;
+        let tp = self.read_board_id(Framework12Adc::TouchpadBoardId as u8)?;
 
         let is_present = |p| if p { "Present" } else { "Missing" };
 
@@ -1100,12 +1135,12 @@ impl CrosEc {
         Ok(res.adc_value)
     }
 
-    pub fn read_board_id(&self, channel: Framework12Adc) -> EcResult<Option<u8>> {
-        let mv = self.adc_read(channel as u8)?;
+    pub fn read_board_id(&self, channel: u8) -> EcResult<Option<u8>> {
+        let mv = self.adc_read(channel)?;
         if mv < 0 {
             return Err(EcError::DeviceError(format!(
                 "Failed to read ADC channel {}",
-                channel as u8
+                channel
             )));
         }
 

--- a/framework_lib/src/chromium_ec/mod.rs
+++ b/framework_lib/src/chromium_ec/mod.rs
@@ -519,9 +519,11 @@ impl CrosEc {
     }
 
     pub fn print_fw16_inputdeck_status(&self) -> EcResult<()> {
+        let intrusion = self.get_intrusion_status()?;
         let status = self.get_input_deck_status()?;
+        println!("Chassis Open:     {}", intrusion.currently_open);
         println!("Input Deck State: {:?}", status.state);
-        println!("Touchpad present: {:?}", status.touchpad_present);
+        println!("Touchpad present: {}", status.touchpad_present);
         println!("Positions:");
         println!("  Pos 0: {:?}", status.top_row.pos0);
         println!("  Pos 1: {:?}", status.top_row.pos1);

--- a/framework_lib/src/commandline/clap_std.rs
+++ b/framework_lib/src/commandline/clap_std.rs
@@ -141,7 +141,7 @@ struct ClapCli {
 
     /// Show status of the input modules (Framework 16 only)
     #[arg(long)]
-    inputmodules: bool,
+    inputdeck: bool,
 
     /// Set input deck power mode [possible values: auto, off, on] (Framework 16 only)
     #[arg(long)]
@@ -354,7 +354,7 @@ pub fn parse(args: &[String]) -> Cli {
             .flash_rw_ec
             .map(|x| x.into_os_string().into_string().unwrap()),
         intrusion: args.intrusion,
-        inputmodules: args.inputmodules,
+        inputdeck: args.inputdeck,
         input_deck_mode: args.input_deck_mode,
         expansion_bay: args.expansion_bay,
         charge_limit: args.charge_limit,

--- a/framework_lib/src/commandline/clap_std.rs
+++ b/framework_lib/src/commandline/clap_std.rs
@@ -145,7 +145,7 @@ struct ClapCli {
 
     /// Set input deck power mode [possible values: auto, off, on] (Framework 16 only)
     #[arg(long)]
-    input_deck_mode: Option<InputDeckModeArg>,
+    inputdeck_mode: Option<InputDeckModeArg>,
 
     /// Show status of the expansion bay (Framework 16 only)
     #[arg(long)]
@@ -355,7 +355,7 @@ pub fn parse(args: &[String]) -> Cli {
             .map(|x| x.into_os_string().into_string().unwrap()),
         intrusion: args.intrusion,
         inputdeck: args.inputdeck,
-        input_deck_mode: args.input_deck_mode,
+        inputdeck_mode: args.inputdeck_mode,
         expansion_bay: args.expansion_bay,
         charge_limit: args.charge_limit,
         get_gpio: args.get_gpio,

--- a/framework_lib/src/commandline/mod.rs
+++ b/framework_lib/src/commandline/mod.rs
@@ -171,7 +171,7 @@ pub struct Cli {
     pub driver: Option<CrosEcDriverType>,
     pub test: bool,
     pub intrusion: bool,
-    pub inputmodules: bool,
+    pub inputdeck: bool,
     pub input_deck_mode: Option<InputDeckModeArg>,
     pub expansion_bay: bool,
     pub charge_limit: Option<Option<u8>>,
@@ -745,7 +745,7 @@ pub fn run_with_args(args: &Cli, _allupdate: bool) -> i32 {
         } else {
             println!("  Unable to tell");
         }
-    } else if args.inputmodules {
+    } else if args.inputdeck {
         println!("Input Module Status:");
         if let Some(status) = print_err(ec.get_input_deck_status()) {
             println!("Input Deck State: {:?}", status.state);
@@ -1083,7 +1083,7 @@ Options:
       --flash-rw-ec <FLASH_EC>         Flash EC with new firmware from file
       --reboot-ec            Control EC RO/RW jump [possible values: reboot, jump-ro, jump-rw, cancel-jump, disable-jump]
       --intrusion            Show status of intrusion switch
-      --inputmodules         Show status of the input modules (Framework 16 only)
+      --inputdeck            Show status of the input deck
       --input-deck-mode      Set input deck power mode [possible values: auto, off, on] (Framework 16 only)
       --expansion-bay        Show status of the expansion bay (Framework 16 only)
       --charge-limit [<VAL>] Get or set battery charge limit (Percentage number as arg, e.g. '100')

--- a/framework_lib/src/commandline/mod.rs
+++ b/framework_lib/src/commandline/mod.rs
@@ -748,7 +748,7 @@ pub fn run_with_args(args: &Cli, _allupdate: bool) -> i32 {
     } else if args.inputdeck {
         let res = match smbios::get_platform().and_then(Platform::which_family) {
             Some(PlatformFamily::Framework12) => ec.print_fw12_inputdeck_status(),
-            Some(PlatformFamily::Framework13) => Ok(()),
+            Some(PlatformFamily::Framework13) => ec.print_fw13_inputdeck_status(),
             Some(PlatformFamily::Framework16) => ec.print_fw16_inputdeck_status(),
             _ => Ok(()),
         };

--- a/framework_lib/src/commandline/mod.rs
+++ b/framework_lib/src/commandline/mod.rs
@@ -172,7 +172,7 @@ pub struct Cli {
     pub test: bool,
     pub intrusion: bool,
     pub inputdeck: bool,
-    pub input_deck_mode: Option<InputDeckModeArg>,
+    pub inputdeck_mode: Option<InputDeckModeArg>,
     pub expansion_bay: bool,
     pub charge_limit: Option<Option<u8>>,
     pub get_gpio: Option<String>,
@@ -759,7 +759,7 @@ pub fn run_with_args(args: &Cli, _allupdate: bool) -> i32 {
         } else {
             println!("  Unable to tell");
         }
-    } else if let Some(mode) = &args.input_deck_mode {
+    } else if let Some(mode) = &args.inputdeck_mode {
         println!("Set mode to: {:?}", mode);
         ec.set_input_deck_mode((*mode).into()).unwrap();
     } else if args.expansion_bay {
@@ -1084,7 +1084,7 @@ Options:
       --reboot-ec            Control EC RO/RW jump [possible values: reboot, jump-ro, jump-rw, cancel-jump, disable-jump]
       --intrusion            Show status of intrusion switch
       --inputdeck            Show status of the input deck
-      --input-deck-mode      Set input deck power mode [possible values: auto, off, on] (Framework 16 only)
+      --inputdeck-mode       Set input deck power mode [possible values: auto, off, on] (Framework 16 only)
       --expansion-bay        Show status of the expansion bay (Framework 16 only)
       --charge-limit [<VAL>] Get or set battery charge limit (Percentage number as arg, e.g. '100')
       --get-gpio <GET_GPIO>  Get GPIO value by name

--- a/framework_lib/src/commandline/mod.rs
+++ b/framework_lib/src/commandline/mod.rs
@@ -746,19 +746,7 @@ pub fn run_with_args(args: &Cli, _allupdate: bool) -> i32 {
             println!("  Unable to tell");
         }
     } else if args.inputdeck {
-        println!("Input Module Status:");
-        if let Some(status) = print_err(ec.get_input_deck_status()) {
-            println!("Input Deck State: {:?}", status.state);
-            println!("Touchpad present: {:?}", status.touchpad_present);
-            println!("Positions:");
-            println!("  Pos 0: {:?}", status.top_row.pos0);
-            println!("  Pos 1: {:?}", status.top_row.pos1);
-            println!("  Pos 2: {:?}", status.top_row.pos2);
-            println!("  Pos 3: {:?}", status.top_row.pos3);
-            println!("  Pos 4: {:?}", status.top_row.pos4);
-        } else {
-            println!("  Unable to tell");
-        }
+        let _ = print_err(ec.print_fw16_inputdeck_status());
     } else if let Some(mode) = &args.inputdeck_mode {
         println!("Set mode to: {:?}", mode);
         ec.set_input_deck_mode((*mode).into()).unwrap();

--- a/framework_lib/src/commandline/uefi.rs
+++ b/framework_lib/src/commandline/uefi.rs
@@ -84,7 +84,7 @@ pub fn parse(args: &[String]) -> Cli {
         dump: None,
         h2o_capsule: None,
         intrusion: false,
-        inputmodules: false,
+        inputdeck: false,
         input_deck_mode: None,
         expansion_bay: false,
         charge_limit: None,
@@ -225,8 +225,8 @@ pub fn parse(args: &[String]) -> Cli {
         } else if arg == "--intrusion" {
             cli.intrusion = true;
             found_an_option = true;
-        } else if arg == "--inputmodules" {
-            cli.inputmodules = true;
+        } else if arg == "--inputdeck" {
+            cli.inputdeck = true;
             found_an_option = true;
         } else if arg == "--input-deck-mode" {
             cli.input_deck_mode = if args.len() > i + 1 {

--- a/framework_lib/src/commandline/uefi.rs
+++ b/framework_lib/src/commandline/uefi.rs
@@ -85,7 +85,7 @@ pub fn parse(args: &[String]) -> Cli {
         h2o_capsule: None,
         intrusion: false,
         inputdeck: false,
-        input_deck_mode: None,
+        inputdeck_mode: None,
         expansion_bay: false,
         charge_limit: None,
         get_gpio: None,
@@ -228,22 +228,22 @@ pub fn parse(args: &[String]) -> Cli {
         } else if arg == "--inputdeck" {
             cli.inputdeck = true;
             found_an_option = true;
-        } else if arg == "--input-deck-mode" {
-            cli.input_deck_mode = if args.len() > i + 1 {
-                let input_deck_mode = &args[i + 1];
-                if input_deck_mode == "auto" {
+        } else if arg == "--inputdeck-mode" {
+            cli.inputdeck_mode = if args.len() > i + 1 {
+                let inputdeck_mode = &args[i + 1];
+                if inputdeck_mode == "auto" {
                     Some(InputDeckModeArg::Auto)
-                } else if input_deck_mode == "off" {
+                } else if inputdeck_mode == "off" {
                     Some(InputDeckModeArg::Off)
-                } else if input_deck_mode == "on" {
+                } else if inputdeck_mode == "on" {
                     Some(InputDeckModeArg::On)
                 } else {
-                    println!("Invalid value for --input-deck-mode: {}", input_deck_mode);
+                    println!("Invalid value for --inputdeck-mode: {}", inputdeck_mode);
                     None
                 }
             } else {
                 println!(
-                    "Need to provide a value for --input-deck-mode. Either `auto`, `off`, or `on`"
+                    "Need to provide a value for --inputdeck-mode. Either `auto`, `off`, or `on`"
                 );
                 None
             };

--- a/framework_lib/src/util.rs
+++ b/framework_lib/src/util.rs
@@ -40,6 +40,31 @@ pub enum Platform {
     GenericFramework((u16, u16), (u8, u8), bool),
 }
 
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub enum PlatformFamily {
+    Framework12,
+    Framework13,
+    Framework16,
+    FrameworkDesktop,
+}
+
+impl Platform {
+    pub fn which_family(self) -> Option<PlatformFamily> {
+        match self {
+            Platform::Framework12IntelGen13 => Some(PlatformFamily::Framework12),
+            Platform::IntelGen11
+            | Platform::IntelGen12
+            | Platform::IntelGen13
+            | Platform::IntelCoreUltra1
+            | Platform::Framework13Amd7080
+            | Platform::Framework13AmdAi300 => Some(PlatformFamily::Framework13),
+            Platform::Framework16Amd7080 => Some(PlatformFamily::Framework16),
+            Platform::FrameworkDesktopAmdAiMax300 => Some(PlatformFamily::FrameworkDesktop),
+            Platform::GenericFramework(..) => None,
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct Config {
     // TODO: Actually set and read this

--- a/support-matrices.md
+++ b/support-matrices.md
@@ -37,6 +37,6 @@
 | `--pd-info`      | PD Communication | All              |
 | `--privacy`      | EC Communication | All              |
 | `--intrusion`    | EC Communication | All              |
-| `--inputmodules` | EC Communication | Framework 16     |
+| `--inputdeck`    | EC Communication | Framework 16     |
 | `--console`      | EC Communication | All              |
 | `--kblight`      | EC Communication | All, except FL16 |


### PR DESCRIPTION
Previously only Framework 16, expand to Framework 12.

```
> sudo framework_tool --inputdeck
Input Deck
  Chassis Open:        true
  Power Button Board:  Present
  Audio Daughterboard: Present
  Touchpad:            Present
```

And Framework 13

```
> sudo framework_tool --inputdeck
Input Deck
  Chassis Open:        false
  Audio Daughterboard: Present
  Touchpad:            Present
```