### PR TITLE
Split I2C tunneling out of ccgx module

### DIFF
--- a/framework_lib/src/chromium_ec/i2c_passthrough.rs
+++ b/framework_lib/src/chromium_ec/i2c_passthrough.rs
@@ -1,0 +1,118 @@
+use crate::chromium_ec::command::EcCommands;
+use crate::chromium_ec::{CrosEc, CrosEcDriver, EcError, EcResult};
+use crate::util;
+use alloc::format;
+use alloc::string::ToString;
+use alloc::vec;
+use alloc::vec::Vec;
+use std::mem::size_of;
+
+/// Maximum transfer size for one I2C transaction supported by the chip
+pub const MAX_I2C_CHUNK: usize = 128;
+
+#[repr(C, packed)]
+pub struct EcParamsI2cPassthruMsg {
+    /// Slave address and flags
+    addr_and_flags: u16,
+    transfer_len: u16,
+}
+
+#[repr(C, packed)]
+pub struct EcParamsI2cPassthru {
+    port: u8,
+    /// How many messages
+    messages: u8,
+    msg: [EcParamsI2cPassthruMsg; 0],
+}
+
+#[repr(C, packed)]
+struct _EcI2cPassthruResponse {
+    i2c_status: u8,
+    /// How many messages
+    messages: u8,
+    data: [u8; 0],
+}
+
+#[derive(Debug)]
+pub struct EcI2cPassthruResponse {
+    pub i2c_status: u8, // TODO: Can probably use enum
+    pub data: Vec<u8>,
+}
+
+impl EcI2cPassthruResponse {
+    pub fn is_successful(&self) -> EcResult<()> {
+        if self.i2c_status & 1 > 0 {
+            return Err(EcError::DeviceError(
+                "I2C Transfer not acknowledged".to_string(),
+            ));
+        }
+        if self.i2c_status & (1 << 1) > 0 {
+            return Err(EcError::DeviceError("I2C Transfer timeout".to_string()));
+        }
+        // I'm not aware of any other errors, but there might be.
+        // But I don't think multiple errors can be indicated at the same time
+        assert_eq!(self.i2c_status, 0);
+        Ok(())
+    }
+}
+
+/// Indicate that it's a read, not a write
+const I2C_READ_FLAG: u16 = 1 << 15;
+
+pub fn i2c_read(
+    ec: &CrosEc,
+    i2c_port: u8,
+    i2c_addr: u16,
+    addr: u16,
+    len: u16,
+) -> EcResult<EcI2cPassthruResponse> {
+    trace!(
+        "i2c_read(i2c_port: 0x{:X}, i2c_addr: 0x{:X}, addr: 0x{:X}, len: 0x{:X})",
+        i2c_port,
+        i2c_addr,
+        addr,
+        len
+    );
+    if usize::from(len) > MAX_I2C_CHUNK {
+        return EcResult::Err(EcError::DeviceError(format!(
+            "i2c_read too long. Must be <128, is: {}",
+            len
+        )));
+    }
+    let addr_bytes = u16::to_le_bytes(addr);
+    let messages = vec![
+        EcParamsI2cPassthruMsg {
+            addr_and_flags: i2c_addr,
+            transfer_len: addr_bytes.len() as u16,
+        },
+        EcParamsI2cPassthruMsg {
+            addr_and_flags: i2c_addr + I2C_READ_FLAG,
+            transfer_len: len, // How much to read
+        },
+    ];
+    let msgs_len = size_of::<EcParamsI2cPassthruMsg>() * messages.len();
+    let msgs_buffer: &[u8] = unsafe { util::any_vec_as_u8_slice(&messages) };
+
+    let params = EcParamsI2cPassthru {
+        port: i2c_port,
+        messages: messages.len() as u8,
+        msg: [], // Messages are copied right after this struct
+    };
+    let params_len = size_of::<EcParamsI2cPassthru>();
+    let params_buffer: &[u8] = unsafe { util::any_as_u8_slice(&params) };
+
+    let mut buffer: Vec<u8> = vec![0; params_len + msgs_len + addr_bytes.len()];
+    buffer[0..params_len].copy_from_slice(params_buffer);
+    buffer[params_len..params_len + msgs_len].copy_from_slice(msgs_buffer);
+    buffer[params_len + msgs_len..].copy_from_slice(&addr_bytes);
+
+    let data = ec.send_command(EcCommands::I2cPassthrough as u16, 0, &buffer)?;
+    let res: _EcI2cPassthruResponse = unsafe { std::ptr::read(data.as_ptr() as *const _) };
+    let res_data = &data[size_of::<_EcI2cPassthruResponse>()..];
+    // TODO: Seems to be either one, non-deterministically
+    debug_assert!(res.messages as usize == messages.len() || res.messages == 0);
+    Ok(EcI2cPassthruResponse {
+        i2c_status: res.i2c_status,
+        data: res_data.to_vec(),
+    })
+}

--- a/framework_lib/src/chromium_ec/mod.rs
+++ b/framework_lib/src/chromium_ec/mod.rs
@@ -22,6 +22,7 @@ pub mod command;
 pub mod commands;
 #[cfg(feature = "cros_ec_driver")]
 mod cros_ec;
+pub mod i2c_passthrough;
 pub mod input_deck;
 mod portio;
 mod portio_mec;


### PR DESCRIPTION
Tested i2c_read:

Note that the port number does not seem to always match the right one.

```
# Framework 13 - Ryzen AI 300
# ALS Sensor - different every time if ambient light changes
# Should actually be port number 7, but it seems the zephyr DT mapping changes it to 5, probably because 5 and 6 are unused
i2c_read(0x05, 0x29, 0x04, 0x08)

# Framework 12
# BMA4XX
# ID, returns 0x18
i2c_read(ec, 0x07, 0x18, 0x00, 0x01)
# Time, every time different
i2c_read(ec, 0x07, 0x18, 0x18, 0x01)
# Temperature, usually same
i2c_read(ec, 0x07, 0x18, 0x22, 0x01)
# Temp
i2c_read(ec, 0x06, 0x4D, 0xFD, 0x01)
```

