### PR TITLE
Revert "gh-actions: Disable FreeBSD builds"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,6 @@ on:
 
 jobs:
   freebsd-cross-build:
-    # Not building currently, container seems to have issues
-    if: false
-
     name: Cross-Build for FreeBSD
     runs-on: 'ubuntu-24.04'
     env:


### PR DESCRIPTION
This reverts commit ccd8a3639e7116bbf0ff11e943436d7849223298.

Fixed by https://github.com/cross-rs/cross/pull/1674