### PR TITLE
Fix charge limit based on battery charge

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -291,8 +291,8 @@ Battery Status
   Battery charging
 
 # Set charge rate/current limit only if battery is >80% charged
-> sudo framework_tool --charge-rate-limit 80 0.8
-> sudo framework_tool --charge-current-limit 80 2000
+> sudo framework_tool --charge-rate-limit 0.8 80
+> sudo framework_tool --charge-current-limit 2000 80
 ```
 
 ## Stylus (Framework 12)

--- a/framework_lib/src/commandline/clap_std.rs
+++ b/framework_lib/src/commandline/clap_std.rs
@@ -157,12 +157,12 @@ struct ClapCli {
 
     /// Get or set max charge current limit
     #[arg(long)]
-    #[clap(num_args = ..2)]
+    #[clap(num_args = ..=2)]
     charge_current_limit: Vec<u32>,
 
     /// Get or set max charge current limit
     #[arg(long)]
-    #[clap(num_args = ..2)]
+    #[clap(num_args = ..=2)]
     charge_rate_limit: Vec<f32>,
 
     /// Get GPIO value by name


### PR DESCRIPTION
Following are fixed now

```
> sudo framework_tool --charge-rate-limit 80 0.8
> sudo framework_tool --charge-current-limit 80 2000
```

Reported by: github.com/tjkirch