### PR TITLE
chromium_ec: Use portio if /dev/cros_ec does not exist

### DIFF
--- a/framework_lib/src/chromium_ec/cros_ec.rs
+++ b/framework_lib/src/chromium_ec/cros_ec.rs
@@ -55,7 +55,7 @@ struct CrosEcCommandV2 {
     data: [u8; IN_SIZE],
 }
 
-const DEV_PATH: &str = "/dev/cros_ec";
+pub const DEV_PATH: &str = "/dev/cros_ec";
 
 lazy_static! {
     static ref CROS_EC_FD: Arc<Mutex<Option<std::fs::File>>> = Arc::new(Mutex::new(None));

--- a/framework_lib/src/chromium_ec/mod.rs
+++ b/framework_lib/src/chromium_ec/mod.rs
@@ -239,14 +239,20 @@ impl Default for CrosEc {
 ///
 /// Depending on the availability we choose the first one as default
 fn available_drivers() -> Vec<CrosEcDriverType> {
-    vec![
-        #[cfg(feature = "win_driver")]
-        CrosEcDriverType::Windows,
-        #[cfg(feature = "cros_ec_driver")]
-        CrosEcDriverType::CrosEc,
-        #[cfg(not(feature = "windows"))]
-        CrosEcDriverType::Portio,
-    ]
+    let mut drivers = vec![];
+
+    #[cfg(feature = "win_driver")]
+    drivers.push(CrosEcDriverType::Windows);
+
+    #[cfg(feature = "cros_ec_driver")]
+    if std::path::Path::new(cros_ec::DEV_PATH).exists() {
+        drivers.push(CrosEcDriverType::CrosEc);
+    }
+
+    #[cfg(not(feature = "windows"))]
+    drivers.push(CrosEcDriverType::Portio);
+
+    drivers
 }
 
 impl CrosEc {


### PR DESCRIPTION
Then users don't manually have to specify `--driver portio` if the cros_ec kernel driver is not loaded.