### PR TITLE
chromioum_ec: Autodetect Microchip EC when using portio

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,8 +202,6 @@ Options:
           Specify I2C addresses of the PD chips (Advanced)
       --pd-ports <PD_PORTS> <PD_PORTS>
           Specify I2C ports of the PD chips (Advanced)
-      --has-mec <HAS_MEC>
-          Specify the type of EC chip (MEC/MCHP or other) [possible values: true, false]
   -t, --test                        Run self-test to check if interaction with EC is possible
   -h, --help                        Print help information
 ```

--- a/completions/bash/framework_tool
+++ b/completions/bash/framework_tool
@@ -50,7 +50,6 @@ _framework_tool() {
         "--driver"
         "--pd-addrs"
         "--pd-ports"
-        "--has-mec"
         "-t" "--test"
         "-h" "--help"
     )
@@ -59,7 +58,6 @@ _framework_tool() {
     local inputdeck_modes=("auto" "off" "on")
     local console_modes=("recent" "follow")
     local drivers=("portio" "cros-ec" "windows")
-    local has_mec_options=("true" "false")
     local brightness_options=("high" "medium" "low" "ultra-low")
 
     local current_word prev_word
@@ -77,8 +75,6 @@ _framework_tool() {
         COMPREPLY=( $(compgen -W "${console_modes[*]}" -- "$current_word") )
     elif [[ $prev_word == "--driver" ]]; then
         COMPREPLY=( $(compgen -W "${drivers[*]}" -- "$current_word") )
-    elif [[ $prev_word == "--has-mec" ]]; then
-        COMPREPLY=( $(compgen -W "${has_mec_options[*]}" -- "$current_word") )
     elif [[ $prev_word == "--fp-brightness" ]]; then
         COMPREPLY=( $(compgen -W "${brightness_options[*]}" -- "$current_word") )
     fi

--- a/completions/zsh/_framework_tool
+++ b/completions/zsh/_framework_tool
@@ -48,7 +48,6 @@ options=(
   '--driver[Select which driver is used]:driver:(portio cros-ec windows)'
   '--pd-addrs[Specify I2C addresses of the PD chips (Advanced)]:pd_addrs'
   '--pd-ports[Specify I2C ports of the PD chips (Advanced)]:pd_ports'
-  '--has-mec[Specify the type of EC chip (MEC/MCHP or other)]:has_mec:(true false)'
   '-t[Run self-test to check if interaction with EC is possible]'
   '-h[Print help]'
 )

--- a/framework_lib/src/ccgx/device.rs
+++ b/framework_lib/src/ccgx/device.rs
@@ -41,8 +41,8 @@ impl PdPort {
         let platform = &(*config).as_ref().unwrap().platform;
 
         match (platform, self) {
-            (Platform::GenericFramework((left, _), _, _), PdPort::Left01) => *left,
-            (Platform::GenericFramework((_, right), _, _), PdPort::Right23) => *right,
+            (Platform::GenericFramework((left, _), _), PdPort::Left01) => *left,
+            (Platform::GenericFramework((_, right), _), PdPort::Right23) => *right,
             // Framework AMD Platforms (CCG8)
             (
                 Platform::Framework13Amd7080
@@ -70,8 +70,8 @@ impl PdPort {
         let platform = &(*config).as_ref().unwrap().platform;
 
         Ok(match (platform, self) {
-            (Platform::GenericFramework(_, (left, _), _), PdPort::Left01) => *left,
-            (Platform::GenericFramework(_, (_, right), _), PdPort::Right23) => *right,
+            (Platform::GenericFramework(_, (left, _)), PdPort::Left01) => *left,
+            (Platform::GenericFramework(_, (_, right)), PdPort::Right23) => *right,
             (Platform::IntelGen11, _) => 6,
             (Platform::IntelGen12 | Platform::IntelGen13, PdPort::Left01) => 6,
             (Platform::IntelGen12 | Platform::IntelGen13, PdPort::Right23) => 7,

--- a/framework_lib/src/chromium_ec/mod.rs
+++ b/framework_lib/src/chromium_ec/mod.rs
@@ -268,6 +268,7 @@ impl CrosEc {
             return None;
         }
         debug!("Chromium EC Driver: {:?}", driver);
+
         Some(CrosEc { driver })
     }
 

--- a/framework_lib/src/chromium_ec/portio_mec.rs
+++ b/framework_lib/src/chromium_ec/portio_mec.rs
@@ -22,10 +22,12 @@ const _MEC_LPC_DATA_REGISTER1: u16 = 0x0805;
 const MEC_LPC_DATA_REGISTER2: u16 = 0x0806;
 const _MEC_LPC_DATA_REGISTER3: u16 = 0x0807;
 
-#[cfg(feature = "linux_pio")]
-pub unsafe fn mec_init() {
-    ioperm(EC_LPC_ADDR_HOST_DATA as u64, 8, 1);
-    ioperm(MEC_LPC_ADDRESS_REGISTER0 as u64, 10, 1);
+pub fn init() {
+    #[cfg(feature = "linux_pio")]
+    unsafe {
+        ioperm(EC_LPC_ADDR_HOST_DATA as u64, 8, 1);
+        ioperm(MEC_LPC_ADDRESS_REGISTER0 as u64, 10, 1);
+    }
 }
 
 // TODO: Create a wrapper

--- a/framework_lib/src/commandline/clap_std.rs
+++ b/framework_lib/src/commandline/clap_std.rs
@@ -228,19 +228,14 @@ struct ClapCli {
     driver: Option<CrosEcDriverType>,
 
     /// Specify I2C addresses of the PD chips (Advanced)
-    #[clap(number_of_values = 2, requires("pd_ports"), requires("has_mec"))]
+    #[clap(number_of_values = 2, requires("pd_ports"))]
     #[arg(long)]
     pd_addrs: Vec<u16>,
 
     /// Specify I2C ports of the PD chips (Advanced)
-    #[clap(number_of_values = 2, requires("pd_addrs"), requires("has_mec"))]
+    #[clap(number_of_values = 2, requires("pd_addrs"))]
     #[arg(long)]
     pd_ports: Vec<u8>,
-
-    /// Specify the type of EC chip (MEC/MCHP or other)
-    #[clap(requires("pd_addrs"), requires("pd_ports"))]
-    #[arg(long)]
-    has_mec: Option<bool>,
 
     /// Run self-test to check if interaction with EC is possible
     #[arg(long, short)]
@@ -408,7 +403,6 @@ pub fn parse(args: &[String]) -> Cli {
         driver: args.driver,
         pd_addrs,
         pd_ports,
-        has_mec: args.has_mec,
         test: args.test,
         // TODO: Set help. Not very important because Clap handles this by itself
         help: false,

--- a/framework_lib/src/commandline/mod.rs
+++ b/framework_lib/src/commandline/mod.rs
@@ -191,7 +191,6 @@ pub struct Cli {
     pub hash: Option<String>,
     pub pd_addrs: Option<(u16, u16)>,
     pub pd_ports: Option<(u8, u8)>,
-    pub has_mec: Option<bool>,
     pub help: bool,
     pub info: bool,
     pub flash_gpu_descriptor: Option<(u8, String)>,
@@ -701,12 +700,8 @@ pub fn run_with_args(args: &Cli, _allupdate: bool) -> i32 {
     }
 
     // Must be run before any application code to set the config
-    if args.pd_addrs.is_some() && args.pd_ports.is_some() && args.has_mec.is_some() {
-        let platform = Platform::GenericFramework(
-            args.pd_addrs.unwrap(),
-            args.pd_ports.unwrap(),
-            args.has_mec.unwrap(),
-        );
+    if args.pd_addrs.is_some() && args.pd_ports.is_some() {
+        let platform = Platform::GenericFramework(args.pd_addrs.unwrap(), args.pd_ports.unwrap());
         Config::set(platform);
     }
 
@@ -1169,7 +1164,7 @@ fn selftest(ec: &CrosEc) -> Option<()> {
     } else {
         println!("  SMBIOS Platform:     Unknown");
         println!();
-        println!("Specify custom platform parameters with --pd-ports --pd-addrs --has-mec");
+        println!("Specify custom platform parameters with --pd-ports --pd-addrs");
         return None;
     };
 

--- a/framework_lib/src/commandline/uefi.rs
+++ b/framework_lib/src/commandline/uefi.rs
@@ -106,7 +106,6 @@ pub fn parse(args: &[String]) -> Cli {
         driver: Some(CrosEcDriverType::Portio),
         pd_addrs: None,
         pd_ports: None,
-        has_mec: None,
         test: false,
         help: false,
         flash_gpu_descriptor: None,
@@ -610,22 +609,6 @@ pub fn parse(args: &[String]) -> Cli {
                 None
             };
             found_an_option = true;
-        } else if arg == "--has-mec" {
-            cli.has_mec = if args.len() > i + 1 {
-                if let Ok(b) = args[i + 1].parse::<bool>() {
-                    Some(b)
-                } else {
-                    println!(
-                        "Invalid value for --has-mec: '{}'. Must be 'true' or 'false'.",
-                        args[i + 1]
-                    );
-                    None
-                }
-            } else {
-                println!("--has-mec requires extra boolean argument.");
-                None
-            };
-            found_an_option = true;
         } else if arg == "--raw-command" {
             cli.raw_command = args[1..].to_vec();
         } else if arg == "--compare-version" {
@@ -699,11 +682,10 @@ pub fn parse(args: &[String]) -> Cli {
         }
     }
 
-    let custom_platform = cli.pd_addrs.is_some() && cli.pd_ports.is_some() && cli.has_mec.is_some();
-    let no_customization =
-        cli.pd_addrs.is_none() && cli.pd_ports.is_none() && cli.has_mec.is_none();
+    let custom_platform = cli.pd_addrs.is_some() && cli.pd_ports.is_some();
+    let no_customization = cli.pd_addrs.is_none() && cli.pd_ports.is_none();
     if !(custom_platform || no_customization) {
-        println!("To customize the platform you need to provide all of --pd-addrs, --pd-ports and --has-mec");
+        println!("To customize the platform you need to provide all of --pd-addrs, and --pd-ports");
     }
 
     if args.len() == 1 && cli.paginate {

--- a/framework_lib/src/smbios.rs
+++ b/framework_lib/src/smbios.rs
@@ -46,7 +46,7 @@ pub enum ConfigDigit0 {
 pub fn is_framework() -> bool {
     if matches!(
         get_platform(),
-        Some(Platform::GenericFramework((_, _), (_, _), _))
+        Some(Platform::GenericFramework((_, _), (_, _)))
     ) {
         return true;
     }
@@ -252,7 +252,7 @@ pub fn get_platform() -> Option<Platform> {
         // Except if it's a GenericFramework platform
         let config = Config::get();
         let platform = &(*config).as_ref().unwrap().platform;
-        if matches!(platform, Platform::GenericFramework((_, _), (_, _), _)) {
+        if matches!(platform, Platform::GenericFramework((_, _), (_, _))) {
             return Some(*platform);
         }
     }

--- a/framework_lib/src/util.rs
+++ b/framework_lib/src/util.rs
@@ -36,8 +36,8 @@ pub enum Platform {
     /// Framework Desktop - AMD Ryzen AI Max 300
     FrameworkDesktopAmdAiMax300,
     /// Generic Framework device
-    /// pd_addrs, pd_ports, has_mec
-    GenericFramework((u16, u16), (u8, u8), bool),
+    /// pd_addrs, pd_ports
+    GenericFramework((u16, u16), (u8, u8)),
 }
 
 #[derive(Debug, PartialEq, Clone, Copy)]

--- a/rgbkbd.py
+++ b/rgbkbd.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # Example invocation in fish shell
 # cargo build && sudo ./target/debug/framework_tool \
-#   --driver portio --has-mec false --pd-ports 1 1 --pd-addrs 64 64 \
+#   --driver portio --pd-ports 1 1 --pd-addrs 64 64 \
 #   (./rgbkbd.py | string split ' ')
 
 BRIGHTNESS = 1


### PR DESCRIPTION
Shouldn't change behavior, but now we don't need to `--has-mec` commandline flag anymore. Previously we needed it when the system type couldn't be detected. 