### PR TITLE
Simplify features and detect based on OS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       run: cargo install cross
 
     - name: Build FreeBSD tool
-      run: cross build --target=x86_64-unknown-freebsd --no-default-features --features cross_freebsd
+      run: cross build --target=x86_64-unknown-freebsd --no-default-features -p framework_lib
 
     - name: Upload FreeBSD App
       uses: actions/upload-artifact@v4
@@ -93,15 +93,15 @@ jobs:
 
     # Build debug library first to fail fast
     - name: Build library (Windows)
-      run: cargo build -p framework_lib --no-default-features --features "windows"
+      run: cargo build -p framework_lib
 
     - name: Build Windows tool
       run: |
-        cargo build -p framework_tool --no-default-features --features "windows"
-        cargo build -p framework_tool --no-default-features --features "windows" --release
+        cargo build -p framework_tool
+        cargo build -p framework_tool --release
 
     - name: Check if Windows tool can start
-      run: cargo run --no-default-features --features "windows" -- --help --release
+      run: cargo run -- --help --release
 
     # Upload release build so that vcruntime is statically linked
     - name: Upload Windows App

--- a/README.md
+++ b/README.md
@@ -130,23 +130,10 @@ Building on Windows or in general with fewer features:
 
 ```ps1
 # Build the library and tool
-cargo build --no-default-features --features "windows"
+cargo build
 
 # Running the tool
-cargo run --no-default-features --features "windows"
-```
-
-Cross compile from Linux to FreeBSD:
-
-```sh
-# One time, install cross tool
-cargo install cross
-
-# Make sure docker is started as well
-sudo systemctl start docker
-
-# Build
-cross build --target=x86_64-unknown-freebsd --no-default-features --features unix
+cargo run
 ```
 
 ## Running
@@ -375,8 +362,8 @@ Keyboard backlight: 0%
 sudo pkg install hidapi
 
 # Build the library and tool
-cargo build --no-default-features --features freebsd
+cargo build
 
 # Running the tool
-cargo run --no-default-features --features freebsd
+cargo run
 ```

--- a/framework_lib/Cargo.toml
+++ b/framework_lib/Cargo.toml
@@ -8,38 +8,17 @@ rust-version = "1.74"
 build = "build.rs"
 
 [features]
-default = ["linux"]
-# Linux/FreeBSD
-unix = ["std", "raw_pio", "smbios", "dep:nix", "dep:libc"]
-linux = ["unix", "linux_pio", "cros_ec_driver", "hidapi", "rusb"]
-freebsd = ["unix", "freebsd_pio", "hidapi", "rusb"]
-# hidapi and rusb don't seem to build in the cross container at the moment
-cross_freebsd = ["unix", "freebsd_pio"]
-# Windows does not have the cros_ec driver nor raw port I/O access to userspace
-windows = ["std", "smbios", "dep:windows", "win_driver", "raw_pio", "hidapi", "rusb", "dep:wmi"]
-smbios = ["dep:smbios-lib"]
-std = ["dep:clap", "dep:clap-num", "dep:clap-verbosity-flag", "dep:env_logger", "smbios-lib?/std"]
+default = ["std"]
+std = ["hidapi", "rusb"]
 rusb = ["dep:rusb"]
 hidapi = ["dep:hidapi"]
 uefi = [
-    "dep:plain", "raw_pio", "smbios", "lazy_static/spin_no_std", "dep:uefi", "dep:uefi-services",
+    "lazy_static/spin_no_std",
     # Otherwise I get: `LLVM ERROR: Do not know how to split the result of this operator!`
     # Seems to be a Ruset/LLVM bug when SSE is enabled.
     # See: https://github.com/rust-lang/rust/issues/61721
     "sha2/force-soft"
 ]
-
-# EC communication via Port I/O on FreeBSD
-freebsd_pio = ["redox_hwio/std"]
-# EC communication via Port I/O on Linux
-linux_pio = ["dep:libc", "redox_hwio/std"]
-# EC communication via raw Port I/O (e.g. UEFI or other ring 0 code)
-raw_pio = []
-# EC communication via cros_ec driver on Linux
-cros_ec_driver = []
-
-# Chromium EC driver by DHowett
-win_driver = []
 
 [build-dependencies]
 built = { version = "0.5", features = ["chrono", "git2"] }
@@ -48,39 +27,42 @@ built = { version = "0.5", features = ["chrono", "git2"] }
 lazy_static = "1.4.0"
 sha2 = { version = "0.10.8", default-features = false, features = [ "force-soft" ] }
 regex = { version = "1.11.1", default-features = false }
-redox_hwio = { git = "https://github.com/FrameworkComputer/rust-hwio", branch = "freebsd", default-features = false }
-libc = { version = "0.2.155", optional = true }
-clap = { version = "4.5", features = ["derive", "cargo"], optional = true }
-clap-num = { version = "1.2.0", optional = true }
-clap-verbosity-flag = { version = "2.2.1", optional = true }
-nix = { version = "0.29.0", features = ["ioctl", "user"], optional = true }
 num = { version = "0.4", default-features = false }
 num-derive = { version = "0.4", default-features = false }
 num-traits = { version = "0.2", default-features = false }
-env_logger = { version = "0.11", optional = true }
 log = { version = "0.4", default-features = true }
-uefi = { version = "0.20", features = ["alloc"], optional = true }
-uefi-services = { version = "0.17", optional = true }
-plain = { version = "0.2.3", optional = true }
-spin = { version = "0.9.8", optional = false }
-hidapi = { version = "2.6.3", optional = true, features = [ "windows-native" ] }
-rusb = { version = "0.9.4", optional = true }
+spin = { version = "0.9.8" }
 no-std-compat = { version = "0.4.1", features = [ "alloc" ] }
 guid_macros = { path = "../guid_macros" }
-wmi = { version = "0.15.0", optional = true }
+hidapi = { version = "2.6.3", features = [ "windows-native" ], optional = true }
+rusb = { version = "0.9.4", optional = true }
 
-[dependencies.smbios-lib]
-git = "https://github.com/FrameworkComputer/smbios-lib.git"
-branch = "no-std"
-optional = true
-default-features = false
-# Local development
-#path = "../../smbios-lib"
-# After my changes are upstreamed
-#version = "0.9.0"
+[target.'cfg(target_os = "uefi")'.dependencies]
+uefi = { version = "0.20", features = ["alloc"] }
+uefi-services = "0.17"
+plain = "0.2.3"
+redox_hwio = { git = "https://github.com/FrameworkComputer/rust-hwio", branch = "freebsd", default-features = false }
+smbios-lib = { git = "https://github.com/FrameworkComputer/smbios-lib.git", branch = "no-std", default-features = false }
 
-[dependencies.windows]
-optional = true
+[target.'cfg(windows)'.dependencies]
+wmi = "0.15.0"
+smbios-lib = { git = "https://github.com/FrameworkComputer/smbios-lib.git", branch = "no-std" }
+env_logger = "0.11"
+clap = { version = "4.5", features = ["derive", "cargo"] }
+clap-num = { version = "1.2.0" }
+clap-verbosity-flag = { version = "2.2.1" }
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2.155"
+nix = { version = "0.29.0", features = ["ioctl", "user"] }
+redox_hwio = { git = "https://github.com/FrameworkComputer/rust-hwio", branch = "freebsd" }
+smbios-lib = { git = "https://github.com/FrameworkComputer/smbios-lib.git", branch = "no-std" }
+env_logger = "0.11"
+clap = { version = "4.5", features = ["derive", "cargo"] }
+clap-num = { version = "1.2.0" }
+clap-verbosity-flag = { version = "2.2.1" }
+
+[target.'cfg(windows)'.dependencies.windows]
 version = "0.59.0"
 features = [
     "Win32_Foundation",

--- a/framework_lib/Cargo.toml
+++ b/framework_lib/Cargo.toml
@@ -8,8 +8,7 @@ rust-version = "1.74"
 build = "build.rs"
 
 [features]
-default = ["std"]
-std = ["hidapi", "rusb"]
+default = ["hidapi", "rusb"]
 rusb = ["dep:rusb"]
 hidapi = ["dep:hidapi"]
 uefi = [ "lazy_static/spin_no_std" ]

--- a/framework_lib/Cargo.toml
+++ b/framework_lib/Cargo.toml
@@ -12,13 +12,7 @@ default = ["std"]
 std = ["hidapi", "rusb"]
 rusb = ["dep:rusb"]
 hidapi = ["dep:hidapi"]
-uefi = [
-    "lazy_static/spin_no_std",
-    # Otherwise I get: `LLVM ERROR: Do not know how to split the result of this operator!`
-    # Seems to be a Ruset/LLVM bug when SSE is enabled.
-    # See: https://github.com/rust-lang/rust/issues/61721
-    "sha2/force-soft"
-]
+uefi = [ "lazy_static/spin_no_std" ]
 
 [build-dependencies]
 built = { version = "0.5", features = ["chrono", "git2"] }

--- a/framework_lib/src/capsule.rs
+++ b/framework_lib/src/capsule.rs
@@ -11,9 +11,9 @@
 use std::prelude::v1::*;
 
 use core::prelude::rust_2021::derive;
-#[cfg(all(not(feature = "uefi"), feature = "std"))]
+#[cfg(not(feature = "uefi"))]
 use std::fs::File;
-#[cfg(all(not(feature = "uefi"), feature = "std"))]
+#[cfg(not(feature = "uefi"))]
 use std::io::prelude::*;
 
 #[cfg(not(feature = "uefi"))]
@@ -180,7 +180,7 @@ pub fn dump_winux_image(data: &[u8], header: &DisplayCapsule, filename: &str) {
 
     let image = &data[header_len..image_size];
 
-    #[cfg(all(not(feature = "uefi"), feature = "std"))]
+    #[cfg(not(feature = "uefi"))]
     {
         let mut file = File::create(filename).unwrap();
         file.write_all(image).unwrap();

--- a/framework_lib/src/chromium_ec/command.rs
+++ b/framework_lib/src/chromium_ec/command.rs
@@ -173,9 +173,9 @@ pub trait EcRequestRaw<R> {
     {
         let response = self.send_command_vec_extra(ec, extra_data)?;
         // TODO: The Windows driver seems to return 20 more bytes than expected
-        #[cfg(feature = "win_driver")]
+        #[cfg(windows)]
         let expected = response.len() != std::mem::size_of::<R>() + 20;
-        #[cfg(not(feature = "win_driver"))]
+        #[cfg(not(windows))]
         let expected = response.len() != std::mem::size_of::<R>();
         if expected {
             return Err(EcError::DeviceError(format!(

--- a/framework_lib/src/chromium_ec/portio.rs
+++ b/framework_lib/src/chromium_ec/portio.rs
@@ -4,129 +4,20 @@ use alloc::string::ToString;
 use alloc::vec;
 use alloc::vec::Vec;
 use core::convert::TryInto;
-#[cfg(any(feature = "linux_pio", feature = "freebsd_pio", feature = "raw_pio"))]
+#[cfg(not(windows))]
 use hwio::{Io, Pio};
-#[cfg(all(feature = "linux_pio", target_os = "linux"))]
+#[cfg(target_os = "linux")]
 use libc::ioperm;
 use log::Level;
-#[cfg(feature = "linux_pio")]
+#[cfg(target_os = "linux")]
 use nix::unistd::Uid;
 use num::FromPrimitive;
 use spin::Mutex;
 
+use crate::chromium_ec::protocol::*;
 use crate::chromium_ec::{portio_mec, EC_MEMMAP_ID};
 use crate::os_specific;
 use crate::util;
-
-/*
- * Value written to legacy command port / prefix byte to indicate protocol
- * 3+ structs are being used.  Usage is bus-dependent.
- */
-const EC_COMMAND_PROTOCOL_3: u8 = 0xda;
-
-// LPC command status byte masks
-/// EC has written data but host hasn't consumed it yet
-const _EC_LPC_STATUS_TO_HOST: u8 = 0x01;
-/// Host has written data/command but EC hasn't consumed it yet
-const EC_LPC_STATUS_FROM_HOST: u8 = 0x02;
-/// EC is still processing a command
-const EC_LPC_STATUS_PROCESSING: u8 = 0x04;
-/// Previous command wasn't data but command
-const _EC_LPC_STATUS_LAST_CMD: u8 = 0x08;
-/// EC is in burst mode
-const _EC_LPC_STATUS_BURST_MODE: u8 = 0x10;
-/// SCI event is pending (requesting SCI query)
-const _EC_LPC_STATUS_SCI_PENDING: u8 = 0x20;
-/// SMI event is pending (requesting SMI query)
-const _EC_LPC_STATUS_SMI_PENDING: u8 = 0x40;
-/// Reserved
-const _EC_LPC_STATUS_RESERVED: u8 = 0x80;
-
-/// EC is busy
-const EC_LPC_STATUS_BUSY_MASK: u8 = EC_LPC_STATUS_FROM_HOST | EC_LPC_STATUS_PROCESSING;
-
-// I/O addresses for ACPI commands
-const _EC_LPC_ADDR_ACPI_DATA: u16 = 0x62;
-const _EC_LPC_ADDR_ACPI_CMD: u16 = 0x66;
-
-// I/O addresses for host command
-const EC_LPC_ADDR_HOST_DATA: u16 = 0x200;
-const EC_LPC_ADDR_HOST_CMD: u16 = 0x204;
-
-// I/O addresses for host command args and params
-// Protocol version 2
-const EC_LPC_ADDR_HOST_ARGS: u16 = 0x800; /* And 0x801, 0x802, 0x803 */
-const _EC_LPC_ADDR_HOST_PARAM: u16 = 0x804; /* For version 2 params; size is
-                                             * EC_PROTO2_MAX_PARAM_SIZE */
-// Protocol version 3
-const _EC_LPC_ADDR_HOST_PACKET: u16 = 0x800; /* Offset of version 3 packet */
-const EC_LPC_HOST_PACKET_SIZE: u16 = 0x100; /* Max size of version 3 packet */
-
-const MEC_MEMMAP_OFFSET: u16 = 0x100;
-const NPC_MEMMAP_OFFSET: u16 = 0xE00;
-
-// The actual block is 0x800-0x8ff, but some BIOSes think it's 0x880-0x8ff
-// and they tell the kernel that so we have to think of it as two parts.
-const _EC_HOST_CMD_REGION0: u16 = 0x800;
-const _EC_HOST_CMD_REGION1: u16 = 0x8800;
-const _EC_HOST_CMD_REGION_SIZE: u16 = 0x80;
-
-// EC command register bit functions
-const _EC_LPC_CMDR_DATA: u16 = 1 << 0; // Data ready for host to read
-const _EC_LPC_CMDR_PENDING: u16 = 1 << 1; // Write pending to EC
-const _EC_LPC_CMDR_BUSY: u16 = 1 << 2; // EC is busy processing a command
-const _EC_LPC_CMDR_CMD: u16 = 1 << 3; // Last host write was a command
-const _EC_LPC_CMDR_ACPI_BRST: u16 = 1 << 4; // Burst mode (not used)
-const _EC_LPC_CMDR_SCI: u16 = 1 << 5; // SCI event is pending
-const _EC_LPC_CMDR_SMI: u16 = 1 << 6; // SMI event is pending
-
-const EC_HOST_REQUEST_VERSION: u8 = 3;
-
-/// Request header of version 3
-#[repr(C, packed)]
-struct EcHostRequest {
-    /// Version of this request structure (must be 3)
-    pub struct_version: u8,
-
-    /// Checksum of entire request (header and data)
-    /// Everything added together adds up to 0 (wrapping around u8 limit)
-    pub checksum: u8,
-
-    /// Command number
-    pub command: u16,
-
-    /// Command version, usually 0
-    pub command_version: u8,
-
-    /// Reserved byte in protocol v3. Must be 0
-    pub reserved: u8,
-
-    /// Data length. Data is immediately after the header
-    pub data_len: u16,
-}
-
-const EC_HOST_RESPONSE_VERSION: u8 = 3;
-
-/// Response header of version 3
-#[repr(C, packed)]
-struct EcHostResponse {
-    /// Version of this request structure (must be 3)
-    pub struct_version: u8,
-
-    /// Checksum of entire request (header and data)
-    pub checksum: u8,
-
-    /// Status code of response. See enum _EcStatus
-    pub result: u16,
-
-    /// Data length. Data is immediately after the header
-    pub data_len: u16,
-
-    /// Reserved byte in protocol v3. Must be 0
-    pub reserved: u16,
-}
-#[allow(dead_code)]
-pub const HEADER_LEN: usize = std::mem::size_of::<EcHostResponse>();
 
 fn transfer_write(buffer: &[u8]) {
     if has_mec() {
@@ -209,13 +100,13 @@ fn init() -> bool {
 
     // In Linux userspace has to first request access to ioports
     // TODO: Close these again after we're done
-    #[cfg(feature = "linux_pio")]
+    #[cfg(target_os = "linux")]
     if !Uid::effective().is_root() {
         error!("Must be root to use port based I/O for EC communication.");
         *init = Initialized::Failed;
         return false;
     }
-    #[cfg(feature = "linux_pio")]
+    #[cfg(target_os = "linux")]
     unsafe {
         // 8 for request/response header, 0xFF for response
         let res = ioperm(EC_LPC_ADDR_HOST_ARGS as u64, 8 + 0xFF, 1);

--- a/framework_lib/src/chromium_ec/portio_mec.rs
+++ b/framework_lib/src/chromium_ec/portio_mec.rs
@@ -5,11 +5,11 @@ use alloc::vec::Vec;
 use log::Level;
 
 use hwio::{Io, Pio};
-#[cfg(feature = "linux_pio")]
+#[cfg(target_os = "linux")]
 use libc::ioperm;
 
 // I/O addresses for host command
-#[cfg(feature = "linux_pio")]
+#[cfg(target_os = "linux")]
 const EC_LPC_ADDR_HOST_DATA: u16 = 0x200;
 
 const MEC_EC_BYTE_ACCESS: u16 = 0x00;
@@ -23,7 +23,7 @@ const MEC_LPC_DATA_REGISTER2: u16 = 0x0806;
 const _MEC_LPC_DATA_REGISTER3: u16 = 0x0807;
 
 pub fn init() {
-    #[cfg(feature = "linux_pio")]
+    #[cfg(target_os = "linux")]
     unsafe {
         ioperm(EC_LPC_ADDR_HOST_DATA as u64, 8, 1);
         ioperm(MEC_LPC_ADDRESS_REGISTER0 as u64, 10, 1);

--- a/framework_lib/src/chromium_ec/protocol.rs
+++ b/framework_lib/src/chromium_ec/protocol.rs
@@ -1,0 +1,108 @@
+/*
+ * Value written to legacy command port / prefix byte to indicate protocol
+ * 3+ structs are being used.  Usage is bus-dependent.
+ */
+pub const EC_COMMAND_PROTOCOL_3: u8 = 0xda;
+
+// LPC command status byte masks
+/// EC has written data but host hasn't consumed it yet
+const _EC_LPC_STATUS_TO_HOST: u8 = 0x01;
+/// Host has written data/command but EC hasn't consumed it yet
+pub const EC_LPC_STATUS_FROM_HOST: u8 = 0x02;
+/// EC is still processing a command
+pub const EC_LPC_STATUS_PROCESSING: u8 = 0x04;
+/// Previous command wasn't data but command
+const _EC_LPC_STATUS_LAST_CMD: u8 = 0x08;
+/// EC is in burst mode
+const _EC_LPC_STATUS_BURST_MODE: u8 = 0x10;
+/// SCI event is pending (requesting SCI query)
+const _EC_LPC_STATUS_SCI_PENDING: u8 = 0x20;
+/// SMI event is pending (requesting SMI query)
+const _EC_LPC_STATUS_SMI_PENDING: u8 = 0x40;
+/// Reserved
+const _EC_LPC_STATUS_RESERVED: u8 = 0x80;
+
+/// EC is busy
+pub const EC_LPC_STATUS_BUSY_MASK: u8 = EC_LPC_STATUS_FROM_HOST | EC_LPC_STATUS_PROCESSING;
+
+// I/O addresses for ACPI commands
+const _EC_LPC_ADDR_ACPI_DATA: u16 = 0x62;
+const _EC_LPC_ADDR_ACPI_CMD: u16 = 0x66;
+
+// I/O addresses for host command
+pub const EC_LPC_ADDR_HOST_DATA: u16 = 0x200;
+pub const EC_LPC_ADDR_HOST_CMD: u16 = 0x204;
+
+// I/O addresses for host command args and params
+// Protocol version 2
+pub const EC_LPC_ADDR_HOST_ARGS: u16 = 0x800; /* And 0x801, 0x802, 0x803 */
+const _EC_LPC_ADDR_HOST_PARAM: u16 = 0x804; /* For version 2 params; size is
+                                             * EC_PROTO2_MAX_PARAM_SIZE */
+// Protocol version 3
+const _EC_LPC_ADDR_HOST_PACKET: u16 = 0x800; /* Offset of version 3 packet */
+pub const EC_LPC_HOST_PACKET_SIZE: u16 = 0x100; /* Max size of version 3 packet */
+
+pub const MEC_MEMMAP_OFFSET: u16 = 0x100;
+pub const NPC_MEMMAP_OFFSET: u16 = 0xE00;
+
+// The actual block is 0x800-0x8ff, but some BIOSes think it's 0x880-0x8ff
+// and they tell the kernel that so we have to think of it as two parts.
+const _EC_HOST_CMD_REGION0: u16 = 0x800;
+const _EC_HOST_CMD_REGION1: u16 = 0x8800;
+const _EC_HOST_CMD_REGION_SIZE: u16 = 0x80;
+
+// EC command register bit functions
+const _EC_LPC_CMDR_DATA: u16 = 1 << 0; // Data ready for host to read
+const _EC_LPC_CMDR_PENDING: u16 = 1 << 1; // Write pending to EC
+const _EC_LPC_CMDR_BUSY: u16 = 1 << 2; // EC is busy processing a command
+const _EC_LPC_CMDR_CMD: u16 = 1 << 3; // Last host write was a command
+const _EC_LPC_CMDR_ACPI_BRST: u16 = 1 << 4; // Burst mode (not used)
+const _EC_LPC_CMDR_SCI: u16 = 1 << 5; // SCI event is pending
+const _EC_LPC_CMDR_SMI: u16 = 1 << 6; // SMI event is pending
+
+pub const EC_HOST_REQUEST_VERSION: u8 = 3;
+
+/// Request header of version 3
+#[repr(C, packed)]
+pub struct EcHostRequest {
+    /// Version of this request structure (must be 3)
+    pub struct_version: u8,
+
+    /// Checksum of entire request (header and data)
+    /// Everything added together adds up to 0 (wrapping around u8 limit)
+    pub checksum: u8,
+
+    /// Command number
+    pub command: u16,
+
+    /// Command version, usually 0
+    pub command_version: u8,
+
+    /// Reserved byte in protocol v3. Must be 0
+    pub reserved: u8,
+
+    /// Data length. Data is immediately after the header
+    pub data_len: u16,
+}
+
+pub const EC_HOST_RESPONSE_VERSION: u8 = 3;
+
+/// Response header of version 3
+#[repr(C, packed)]
+pub struct EcHostResponse {
+    /// Version of this request structure (must be 3)
+    pub struct_version: u8,
+
+    /// Checksum of entire request (header and data)
+    pub checksum: u8,
+
+    /// Status code of response. See enum _EcStatus
+    pub result: u16,
+
+    /// Data length. Data is immediately after the header
+    pub data_len: u16,
+
+    /// Reserved byte in protocol v3. Must be 0
+    pub reserved: u16,
+}
+pub const HEADER_LEN: usize = std::mem::size_of::<EcHostResponse>();

--- a/framework_lib/src/chromium_ec/windows.rs
+++ b/framework_lib/src/chromium_ec/windows.rs
@@ -11,7 +11,7 @@ use windows::{
     },
 };
 
-use crate::chromium_ec::portio::HEADER_LEN;
+use crate::chromium_ec::protocol::HEADER_LEN;
 use crate::chromium_ec::EC_MEMMAP_SIZE;
 use crate::chromium_ec::{EcError, EcResponseStatus, EcResult};
 

--- a/framework_lib/src/commandline/mod.rs
+++ b/framework_lib/src/commandline/mod.rs
@@ -17,7 +17,7 @@ pub mod uefi;
 
 #[cfg(not(feature = "uefi"))]
 use std::fs;
-#[cfg(all(not(feature = "uefi"), feature = "std"))]
+#[cfg(not(feature = "uefi"))]
 use std::io::prelude::*;
 
 #[cfg(feature = "rusb")]
@@ -553,7 +553,7 @@ fn flash_ec(ec: &CrosEc, ec_bin_path: &str, flash_type: EcFlashType) {
 fn dump_ec_flash(ec: &CrosEc, dump_path: &str) {
     let flash_bin = ec.get_entire_ec_flash().unwrap();
 
-    #[cfg(all(not(feature = "uefi"), feature = "std"))]
+    #[cfg(not(feature = "uefi"))]
     {
         let mut file = fs::File::create(dump_path).unwrap();
         file.write_all(&flash_bin).unwrap();

--- a/framework_lib/src/commandline/mod.rs
+++ b/framework_lib/src/commandline/mod.rs
@@ -42,7 +42,7 @@ use crate::chromium_ec::commands::TabletModeOverride;
 use crate::chromium_ec::EcResponseStatus;
 use crate::chromium_ec::{print_err, EcFlashType};
 use crate::chromium_ec::{EcError, EcResult};
-#[cfg(feature = "linux")]
+#[cfg(target_os = "linux")]
 use crate::csme;
 use crate::ec_binary;
 use crate::esrt;
@@ -54,7 +54,7 @@ use crate::smbios::ConfigDigit0;
 use crate::smbios::{dmidecode_string_val, get_smbios, is_framework};
 #[cfg(feature = "hidapi")]
 use crate::touchpad::print_touchpad_fw_ver;
-#[cfg(any(feature = "hidapi", feature = "windows"))]
+#[cfg(feature = "hidapi")]
 use crate::touchscreen;
 #[cfg(feature = "uefi")]
 use crate::uefi::enable_page_break;
@@ -483,7 +483,7 @@ fn print_versions(ec: &CrosEc) {
         }
     }
 
-    #[cfg(feature = "linux")]
+    #[cfg(target_os = "linux")]
     {
         println!("CSME");
         if let Ok(csme) = csme::csme_from_sysfs() {
@@ -821,7 +821,7 @@ pub fn run_with_args(args: &Cli, _allupdate: bool) -> i32 {
         };
         ec.set_tablet_mode(mode);
     } else if let Some(_enable) = &args.touchscreen_enable {
-        #[cfg(any(feature = "hidapi", feature = "windows"))]
+        #[cfg(feature = "hidapi")]
         if touchscreen::enable_touch(*_enable).is_none() {
             error!("Failed to enable/disable touch");
         }
@@ -1151,11 +1151,11 @@ fn hash(data: &[u8]) {
 
     println!("Hashes");
     print!("  SHA256:  ");
-    util::print_buffer_short(sha256);
+    util::print_buffer(sha256);
     print!("  SHA384:  ");
-    util::print_buffer_short(sha384);
+    util::print_buffer(sha384);
     print!("  SHA512:  ");
-    util::print_buffer_short(sha512);
+    util::print_buffer(sha512);
 }
 
 fn selftest(ec: &CrosEc) -> Option<()> {

--- a/framework_lib/src/csme.rs
+++ b/framework_lib/src/csme.rs
@@ -3,11 +3,11 @@
 //! Currently only works on Linux (from sysfs).
 
 use core::fmt;
-#[cfg(feature = "linux")]
+#[cfg(target_os = "linux")]
 use std::fs;
-#[cfg(feature = "linux")]
+#[cfg(target_os = "linux")]
 use std::io;
-#[cfg(feature = "linux")]
+#[cfg(target_os = "linux")]
 use std::path::Path;
 
 pub struct CsmeInfo {
@@ -85,7 +85,7 @@ impl fmt::Display for CsmeVersion {
     }
 }
 
-#[cfg(feature = "linux")]
+#[cfg(target_os = "linux")]
 pub fn csme_from_sysfs() -> io::Result<CsmeInfo> {
     let dir = Path::new("/sys/class/mei");
     let mut csme_info: Option<CsmeInfo> = None;

--- a/framework_lib/src/esrt/mod.rs
+++ b/framework_lib/src/esrt/mod.rs
@@ -22,11 +22,11 @@ use guid_macros::guid;
 #[cfg(feature = "uefi")]
 use uefi::{guid, Guid};
 
-#[cfg(feature = "linux")]
+#[cfg(target_os = "linux")]
 use std::fs;
-#[cfg(feature = "linux")]
+#[cfg(target_os = "linux")]
 use std::io;
-#[cfg(feature = "linux")]
+#[cfg(target_os = "linux")]
 use std::path::Path;
 
 #[cfg(target_os = "freebsd")]
@@ -262,7 +262,7 @@ pub fn print_esrt(esrt: &Esrt) {
     }
 }
 
-#[cfg(all(not(feature = "uefi"), feature = "std", feature = "linux"))]
+#[cfg(target_os = "linux")]
 /// On Linux read the ESRT table from the sysfs
 /// resource_version and resource_count_max are reported by sysfs, so they're defaulted to reaesonable values
 /// capsule_flags in sysfs seems to be 0 always. Not sure why.
@@ -323,7 +323,7 @@ fn esrt_from_sysfs(dir: &Path) -> io::Result<Esrt> {
     Ok(esrt_table)
 }
 
-#[cfg(all(not(feature = "uefi"), feature = "linux", target_os = "linux"))]
+#[cfg(target_os = "linux")]
 pub fn get_esrt() -> Option<Esrt> {
     let res = esrt_from_sysfs(Path::new("/sys/firmware/efi/esrt/entries")).ok();
     if res.is_none() {
@@ -332,7 +332,7 @@ pub fn get_esrt() -> Option<Esrt> {
     res
 }
 
-#[cfg(all(not(feature = "uefi"), feature = "windows"))]
+#[cfg(all(not(feature = "uefi"), windows))]
 pub fn get_esrt() -> Option<Esrt> {
     let mut esrt_table = Esrt {
         resource_count: 0,

--- a/framework_lib/src/lib.rs
+++ b/framework_lib/src/lib.rs
@@ -20,9 +20,9 @@ pub mod camera;
 pub mod inputmodule;
 #[cfg(feature = "hidapi")]
 pub mod touchpad;
-#[cfg(any(feature = "hidapi", feature = "windows"))]
+#[cfg(feature = "hidapi")]
 pub mod touchscreen;
-#[cfg(feature = "windows")]
+#[cfg(all(feature = "hidapi", windows))]
 pub mod touchscreen_win;
 
 #[cfg(feature = "uefi")]

--- a/framework_lib/src/touchscreen.rs
+++ b/framework_lib/src/touchscreen.rs
@@ -1,6 +1,6 @@
 use hidapi::{HidApi, HidDevice};
 
-#[cfg(target_os = "windows")]
+#[cfg(windows)]
 use crate::touchscreen_win;
 
 pub const ILI_VID: u16 = 0x222A;

--- a/framework_lib/src/util.rs
+++ b/framework_lib/src/util.rs
@@ -157,7 +157,7 @@ pub unsafe fn any_vec_as_u8_slice<T: Sized>(p: &[T]) -> &[u8] {
 /// Print a byte buffer as a series of hex bytes
 pub fn print_buffer(buffer: &[u8]) {
     for byte in buffer {
-        print!("{:#X} ", byte);
+        print!("{:02x}", byte);
     }
     println!();
 }
@@ -232,15 +232,8 @@ pub fn find_sequence(haystack: &[u8], needle: &[u8]) -> Option<usize> {
 /// Assert length of an EC response from the windows driver
 /// It's always 20 more than expected. TODO: Figure out why
 pub fn assert_win_len<N: Num + std::fmt::Debug + Ord + NumCast + Copy>(left: N, right: N) {
-    #[cfg(feature = "win_driver")]
+    #[cfg(windows)]
     assert_eq!(left, right + NumCast::from(20).unwrap());
-    #[cfg(not(feature = "win_driver"))]
+    #[cfg(not(windows))]
     assert_eq!(left, right);
-}
-
-pub fn print_buffer_short(buffer: &[u8]) {
-    for byte in buffer {
-        print!("{:02x}", byte);
-    }
-    println!();
 }

--- a/framework_lib/src/util.rs
+++ b/framework_lib/src/util.rs
@@ -6,11 +6,11 @@ use std::prelude::v1::*;
 #[cfg(feature = "uefi")]
 use core::prelude::rust_2021::derive;
 
-#[cfg(not(feature = "std"))]
+#[cfg(feature = "uefi")]
 use alloc::sync::Arc;
-#[cfg(not(feature = "std"))]
+#[cfg(feature = "uefi")]
 use spin::{Mutex, MutexGuard};
-#[cfg(feature = "std")]
+#[cfg(not(feature = "uefi"))]
 use std::sync::{Arc, Mutex, MutexGuard};
 
 use crate::smbios;
@@ -74,9 +74,9 @@ pub struct Config {
 
 impl Config {
     pub fn set(platform: Platform) {
-        #[cfg(feature = "std")]
+        #[cfg(not(feature = "uefi"))]
         let mut config = CONFIG.lock().unwrap();
-        #[cfg(not(feature = "std"))]
+        #[cfg(feature = "uefi")]
         let mut config = CONFIG.lock();
 
         if (*config).is_none() {
@@ -87,9 +87,9 @@ impl Config {
         }
     }
     pub fn is_set() -> bool {
-        #[cfg(feature = "std")]
+        #[cfg(not(feature = "uefi"))]
         let config = CONFIG.lock().unwrap();
-        #[cfg(not(feature = "std"))]
+        #[cfg(feature = "uefi")]
         let config = CONFIG.lock();
 
         (*config).is_some()
@@ -98,9 +98,9 @@ impl Config {
     pub fn get() -> MutexGuard<'static, Option<Self>> {
         trace!("Config::get() entry");
         let unset = {
-            #[cfg(feature = "std")]
+            #[cfg(not(feature = "uefi"))]
             let config = CONFIG.lock().unwrap();
-            #[cfg(not(feature = "std"))]
+            #[cfg(feature = "uefi")]
             let config = CONFIG.lock();
             (*config).is_none()
         };
@@ -115,9 +115,9 @@ impl Config {
             None
         };
 
-        #[cfg(feature = "std")]
+        #[cfg(not(feature = "uefi"))]
         let mut config = CONFIG.lock().unwrap();
-        #[cfg(not(feature = "std"))]
+        #[cfg(feature = "uefi")]
         let mut config = CONFIG.lock();
 
         if new_config.is_some() {

--- a/framework_tool/Cargo.toml
+++ b/framework_tool/Cargo.toml
@@ -3,15 +3,8 @@ name = "framework_tool"
 version = "0.4.0"
 edition = "2021"
 
-[features]
-default = ["linux"]
-linux = ["framework_lib/linux"]
-freebsd = ["framework_lib/freebsd"]
-windows = ["framework_lib/windows"]
-
 [dependencies.framework_lib]
 path = "../framework_lib"
-default-features = false
 
 [build-dependencies]
 # Note: Only takes effect in release builds


### PR DESCRIPTION
Now we can build on Windows and FreeBSD, in addition to previously just Linux: with `cargo build` only!