### PR TITLE
Don't require PD config if platform isn't detected

### DIFF
--- a/framework_lib/src/smbios.rs
+++ b/framework_lib/src/smbios.rs
@@ -46,7 +46,7 @@ pub enum ConfigDigit0 {
 pub fn is_framework() -> bool {
     if matches!(
         get_platform(),
-        Some(Platform::GenericFramework((_, _), (_, _)))
+        Some(Platform::GenericFramework((_, _), (_, _))) | Some(Platform::UnknownSystem)
     ) {
         return true;
     }
@@ -252,7 +252,10 @@ pub fn get_platform() -> Option<Platform> {
         // Except if it's a GenericFramework platform
         let config = Config::get();
         let platform = &(*config).as_ref().unwrap().platform;
-        if matches!(platform, Platform::GenericFramework((_, _), (_, _))) {
+        if matches!(
+            platform,
+            Platform::GenericFramework((_, _), (_, _)) | Platform::UnknownSystem
+        ) {
             return Some(*platform);
         }
     }
@@ -270,7 +273,7 @@ pub fn get_platform() -> Option<Platform> {
         "Laptop 13 (Intel Core Ultra Series 1)" => Some(Platform::IntelCoreUltra1),
         "Laptop 16 (AMD Ryzen 7040 Series)" => Some(Platform::Framework16Amd7080),
         "Desktop (AMD Ryzen AI Max 300 Series)" => Some(Platform::FrameworkDesktopAmdAiMax300),
-        _ => None,
+        _ => Some(Platform::UnknownSystem),
     };
 
     if let Some(platform) = platform {

--- a/framework_lib/src/util.rs
+++ b/framework_lib/src/util.rs
@@ -38,6 +38,7 @@ pub enum Platform {
     /// Generic Framework device
     /// pd_addrs, pd_ports
     GenericFramework((u16, u16), (u8, u8)),
+    UnknownSystem,
 }
 
 #[derive(Debug, PartialEq, Clone, Copy)]
@@ -61,6 +62,7 @@ impl Platform {
             Platform::Framework16Amd7080 => Some(PlatformFamily::Framework16),
             Platform::FrameworkDesktopAmdAiMax300 => Some(PlatformFamily::FrameworkDesktop),
             Platform::GenericFramework(..) => None,
+            Platform::UnknownSystem => None,
         }
     }
 }


### PR DESCRIPTION
Now even if the platform isn't detected, we can run the commands just fine. For example both of these work (if I comment out the smbios entry):

```
framework_tool --versions
framework_tool --versions --pd-ports 1 2 --pd-addrs 66 64
```

The first one just fails accessing I2C passthrough for the PD ports.

This is the final change to allow just running the tool on any system in as many cases as possible - even if the linux kernel or framework_tool dose not recognize the system.