### PR TITLE
--get-gpio: Return all GPIOs if no name was passed

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,8 +171,8 @@ Options:
       --expansion-bay               Show status of the expansion bay (Framework 16 only)
       --charge-limit [<CHARGE_LIMIT>]
           Get or set max charge limit
-      --get-gpio <GET_GPIO>
-          Get GPIO value by name
+      --get-gpio [<GET_GPIO>]
+          Get GPIO value by name or all, if no name provided
       --fp-led-level [<FP_LED_LEVEL>]
           Get or set fingerprint LED brightness level [possible values: high, medium, low, ultra-low, auto]
       --fp-brightness [<FP_BRIGHTNESS>]

--- a/framework_lib/src/chromium_ec/commands.rs
+++ b/framework_lib/src/chromium_ec/commands.rs
@@ -343,6 +343,61 @@ impl EcRequest<EcResponseGpioGetV0> for EcRequestGpioGetV0 {
     }
 }
 
+pub enum GpioGetSubCommand {
+    ByName = 0,
+    Count = 1,
+    Info = 2,
+}
+
+#[repr(C, packed)]
+pub struct EcRequestGpioGetV1Count {
+    pub subcmd: u8,
+}
+
+#[repr(C, packed)]
+pub struct EcRequestGpioGetV1ByName {
+    pub subcmd: u8,
+    pub name: [u8; 32],
+}
+
+#[repr(C, packed)]
+pub struct EcRequestGpioGetV1Info {
+    pub subcmd: u8,
+    pub index: u8,
+}
+
+#[repr(C)]
+pub struct EcResponseGpioGetV1Info {
+    pub val: u8,
+    pub name: [u8; 32],
+    pub flags: u32,
+}
+
+impl EcRequest<EcResponseGpioGetV0> for EcRequestGpioGetV1Count {
+    fn command_id() -> EcCommands {
+        EcCommands::GpioGet
+    }
+    fn command_version() -> u8 {
+        1
+    }
+}
+impl EcRequest<EcResponseGpioGetV0> for EcRequestGpioGetV1ByName {
+    fn command_id() -> EcCommands {
+        EcCommands::GpioGet
+    }
+    fn command_version() -> u8 {
+        1
+    }
+}
+impl EcRequest<EcResponseGpioGetV1Info> for EcRequestGpioGetV1Info {
+    fn command_id() -> EcCommands {
+        EcCommands::GpioGet
+    }
+    fn command_version() -> u8 {
+        1
+    }
+}
+
 #[repr(C, packed)]
 pub struct EcRequestReboot {}
 

--- a/framework_lib/src/commandline/clap_std.rs
+++ b/framework_lib/src/commandline/clap_std.rs
@@ -165,9 +165,9 @@ struct ClapCli {
     #[clap(num_args = ..=2)]
     charge_rate_limit: Vec<f32>,
 
-    /// Get GPIO value by name
+    /// Get GPIO value by name or all, if no name provided
     #[arg(long)]
-    get_gpio: Option<String>,
+    get_gpio: Option<Option<String>>,
 
     /// Get or set fingerprint LED brightness level
     #[arg(long)]

--- a/framework_lib/src/commandline/mod.rs
+++ b/framework_lib/src/commandline/mod.rs
@@ -177,7 +177,7 @@ pub struct Cli {
     pub charge_limit: Option<Option<u8>>,
     pub charge_current_limit: Option<(u32, Option<u32>)>,
     pub charge_rate_limit: Option<(f32, Option<f32>)>,
-    pub get_gpio: Option<String>,
+    pub get_gpio: Option<Option<String>>,
     pub fp_led_level: Option<Option<FpBrightnessArg>>,
     pub fp_brightness: Option<Option<u8>>,
     pub kblight: Option<Option<u8>>,
@@ -791,11 +791,15 @@ pub fn run_with_args(args: &Cli, _allupdate: bool) -> i32 {
     } else if let Some((limit, soc)) = args.charge_rate_limit {
         print_err(ec.set_charge_rate_limit(limit, soc));
     } else if let Some(gpio_name) = &args.get_gpio {
-        print!("Getting GPIO value {}: ", gpio_name);
-        if let Ok(value) = ec.get_gpio(gpio_name) {
-            println!("{:?}", value);
+        if let Some(gpio_name) = gpio_name {
+            print!("GPIO {}: ", gpio_name);
+            if let Ok(value) = ec.get_gpio(gpio_name) {
+                println!("{:?}", value);
+            } else {
+                println!("Not found");
+            }
         } else {
-            println!("Not found");
+            print_err(ec.get_all_gpios());
         }
     } else if let Some(maybe_led_level) = &args.fp_led_level {
         print_err(handle_fp_led_level(&ec, *maybe_led_level));
@@ -1120,7 +1124,7 @@ Options:
       --expansion-bay        Show status of the expansion bay (Framework 16 only)
       --charge-limit [<VAL>] Get or set battery charge limit (Percentage number as arg, e.g. '100')
       --charge-current-limit [<VAL>] Get or set battery current charge limit (Percentage number as arg, e.g. '100')
-      --get-gpio <GET_GPIO>  Get GPIO value by name
+      --get-gpio <GET_GPIO>  Get GPIO value by name or all, if no name provided
       --fp-led-level [<VAL>] Get or set fingerprint LED brightness level [possible values: high, medium, low]
       --fp-brightness [<VAL>]Get or set fingerprint LED brightness percentage
       --kblight [<KBLIGHT>]  Set keyboard backlight percentage or get, if no value provided

--- a/framework_lib/src/commandline/uefi.rs
+++ b/framework_lib/src/commandline/uefi.rs
@@ -329,9 +329,9 @@ pub fn parse(args: &[String]) -> Cli {
             found_an_option = true;
         } else if arg == "--get-gpio" {
             cli.get_gpio = if args.len() > i + 1 {
-                Some(args[i + 1].clone())
+                Some(Some(args[i + 1].clone()))
             } else {
-                None
+                Some(None)
             };
             found_an_option = true;
         } else if arg == "--kblight" {


### PR DESCRIPTION
Another benefit is that you can find out the names of all GPIOs.

```
> sudo framework_tool --get-gpio
ec_espi_rst_l                    0
runpwrok                         1
otg_en                           0
ec_i2c0_clk0                     0
ec_i2c0_sda0                     0
ec_i2c1_clk0                     0
ec_i2c1_sda0                     0
ec_i2c2_clk0                     0
[...]
```