### PR TITLE
--sensors: Get information about sensors

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -173,13 +173,13 @@ ALS:   76 Lux
 ```
 
 ### Accelerometer (Framework 12)
+
 ```
 > sudo framework_tool --sensors
-ALS:    0 Lux
 Accelerometers:
-  Lid Angle:  122 Deg
-  Sensor 1:   X=+0.00G Y=+0.84G, Z=+0.52G
-  Sensor 2:   X=-0.03G Y=+0.00G, Z=+1.01G
+  Lid Angle:   118 Deg
+  Lid Sensor:  X=+0.00G Y=+0.86G, Z=+0.53G
+  Base Sensor: X=-0.03G Y=-0.07G, Z=+1.02G
 ```
 
 ## Set custom fan duty/RPM

--- a/framework_lib/src/chromium_ec/command.rs
+++ b/framework_lib/src/chromium_ec/command.rs
@@ -33,6 +33,7 @@ pub enum EcCommands {
     PwmSetKeyboardBacklight = 0x0023,
     PwmSetFanDuty = 0x0024,
     PwmSetDuty = 0x0025,
+    MotionSense = 0x002B,
     PwmGetDuty = 0x0026,
     SetTabletMode = 0x0031,
     AutoFanCtrl = 0x0052,

--- a/framework_lib/src/chromium_ec/commands.rs
+++ b/framework_lib/src/chromium_ec/commands.rs
@@ -282,6 +282,134 @@ impl EcRequest<EcResponsePwmGetDuty> for EcRequestPwmGetDuty {
     }
 }
 
+#[repr(u8)]
+pub enum MotionSenseCmd {
+    Dump = 0,
+    Info = 1,
+}
+
+#[repr(C, packed)]
+pub struct EcRequestMotionSenseDump {
+    /// MotionSenseCmd::Dump
+    pub cmd: u8,
+    /// Maximal number of sensor the host is expecting.
+    /// 0 means the host is only interested in the number
+    /// of sensors controlled by the EC.
+    pub max_sensor_count: u8,
+}
+
+#[repr(C, packed)]
+pub struct EcResponseMotionSenseDump {
+    /// Flags representing the motion sensor module
+    pub module_flags: u8,
+
+    /// Number of sensors managed directly by the EC
+    pub sensor_count: u8,
+
+    /// Sensor data is truncated if response_max is too small
+    /// for holding all the data.
+    pub sensor: [u8; 0],
+}
+
+impl EcRequest<EcResponseMotionSenseDump> for EcRequestMotionSenseDump {
+    fn command_id() -> EcCommands {
+        EcCommands::MotionSense
+    }
+    fn command_version() -> u8 {
+        1
+    }
+}
+
+#[derive(Debug, FromPrimitive, PartialEq)]
+pub enum MotionSenseType {
+    Accel = 0,
+    Gyro = 1,
+    Mag = 2,
+    Prox = 3,
+    Light = 4,
+    Activity = 5,
+    Baro = 6,
+    Sync = 7,
+    LightRgb = 8,
+}
+
+#[derive(Debug, FromPrimitive)]
+pub enum MotionSenseLocation {
+    Base = 0,
+    Lid = 1,
+    Camera = 2,
+}
+
+#[derive(Debug, FromPrimitive)]
+pub enum MotionSenseChip {
+    Kxcj9 = 0,
+    Lsm6ds0 = 1,
+    Bmi160 = 2,
+    Si1141 = 3,
+    Si1142 = 4,
+    Si1143 = 5,
+    Kx022 = 6,
+    L3gd20h = 7,
+    Bma255 = 8,
+    Bmp280 = 9,
+    Opt3001 = 10,
+    Bh1730 = 11,
+    Gpio = 12,
+    Lis2dh = 13,
+    Lsm6dsm = 14,
+    Lis2de = 15,
+    Lis2mdl = 16,
+    Lsm6ds3 = 17,
+    Lsm6dso = 18,
+    Lng2dm = 19,
+    Tcs3400 = 20,
+    Lis2dw12 = 21,
+    Lis2dwl = 22,
+    Lis2ds = 23,
+    Bmi260 = 24,
+    Icm426xx = 25,
+    Icm42607 = 26,
+    Bma422 = 27,
+    Bmi323 = 28,
+    Bmi220 = 29,
+    Cm32183 = 30,
+    Veml3328 = 31,
+}
+
+#[repr(C, packed)]
+pub struct EcRequestMotionSenseInfo {
+    /// MotionSenseCmd::Info
+    pub cmd: u8,
+    /// Sensor index
+    pub sensor_num: u8,
+}
+
+#[repr(C)]
+pub struct EcResponseMotionSenseInfo {
+    /// See enum MotionSenseInfo
+    pub sensor_type: u8,
+    /// See enum MotionSenseLocation
+    pub location: u8,
+    /// See enum MotionSenseChip
+    pub chip: u8,
+}
+
+#[derive(Debug)]
+pub struct MotionSenseInfo {
+    pub sensor_type: MotionSenseType,
+    pub location: MotionSenseLocation,
+    pub chip: MotionSenseChip,
+}
+
+impl EcRequest<EcResponseMotionSenseInfo> for EcRequestMotionSenseInfo {
+    fn command_id() -> EcCommands {
+        EcCommands::MotionSense
+    }
+    fn command_version() -> u8 {
+        1
+    }
+}
+
 pub enum TabletModeOverride {
     Default = 0,
     ForceTablet = 1,

--- a/framework_lib/src/chromium_ec/mod.rs
+++ b/framework_lib/src/chromium_ec/mod.rs
@@ -353,6 +353,43 @@ impl CrosEc {
         ))
     }
 
+    pub fn motionsense_sensor_count(&self) -> EcResult<u8> {
+        EcRequestMotionSenseDump {
+            cmd: MotionSenseCmd::Dump as u8,
+            max_sensor_count: 0,
+        }
+        .send_command(self)
+        .map(|res| res.sensor_count)
+    }
+
+    pub fn motionsense_sensor_info(&self) -> EcResult<Vec<MotionSenseInfo>> {
+        let count = self.motionsense_sensor_count()?;
+
+        let mut sensors = vec![];
+        for sensor_num in 0..count {
+            let info = EcRequestMotionSenseInfo {
+                cmd: MotionSenseCmd::Info as u8,
+                sensor_num,
+            }
+            .send_command(self)?;
+            sensors.push(MotionSenseInfo {
+                sensor_type: FromPrimitive::from_u8(info.sensor_type).unwrap(),
+                location: FromPrimitive::from_u8(info.location).unwrap(),
+                chip: FromPrimitive::from_u8(info.chip).unwrap(),
+            });
+        }
+        Ok(sensors)
+    }
+
+    pub fn motionsense_sensor_list(&self) -> EcResult<u8> {
+        EcRequestMotionSenseDump {
+            cmd: MotionSenseCmd::Dump as u8,
+            max_sensor_count: 0,
+        }
+        .send_command(self)
+        .map(|res| res.sensor_count)
+    }
+
     /// Get current status of Framework Laptop's microphone and camera privacy switches
     /// [true = device enabled/connected, false = device disabled]
     pub fn get_privacy_info(&self) -> EcResult<(bool, bool)> {

--- a/framework_lib/src/smbios.rs
+++ b/framework_lib/src/smbios.rs
@@ -6,7 +6,7 @@ use std::prelude::v1::*;
 use std::io::ErrorKind;
 
 use crate::util::Config;
-pub use crate::util::Platform;
+pub use crate::util::{Platform, PlatformFamily};
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
 use smbioslib::*;
@@ -269,6 +269,10 @@ pub fn get_baseboard_version() -> Option<ConfigDigit0> {
         }
         None
     })
+}
+
+pub fn get_family() -> Option<PlatformFamily> {
+    get_platform().and_then(Platform::which_family)
 }
 
 pub fn get_platform() -> Option<Platform> {


### PR DESCRIPTION
On Framework 12 (now hides non existant ALS):

```
> framework_tool --sensors -vv
[INFO ] Sensors: 2
[INFO ]   Type: Accel
[INFO ]   Location: Lid
[INFO ]   Chip:     Bma422
[INFO ]   Type: Accel
[INFO ]   Location: Base
[INFO ]   Chip:     Bma422
Accelerometers:
  Lid Angle:  126 Deg
  Sensor 1:   X=-0.01G Y=+0.80G, Z=+0.59G
  Sensor 2:   X=-0.03G Y=+0.00G, Z=+1.00G
```