### PR TITLE
Allow flashing EC RW region

### DIFF
--- a/framework_lib/src/commandline/mod.rs
+++ b/framework_lib/src/commandline/mod.rs
@@ -570,19 +570,14 @@ fn flash_ec(ec: &CrosEc, ec_bin_path: &str, flash_type: EcFlashType) {
     let data = crate::uefi::fs::shell_read_file(ec_bin_path);
     #[cfg(not(feature = "uefi"))]
     let data: Option<Vec<u8>> = {
-        let _data = match fs::read(ec_bin_path) {
+        match fs::read(ec_bin_path) {
             Ok(data) => Some(data),
             // TODO: Perhaps a more user-friendly error
             Err(e) => {
                 println!("Error {:?}", e);
                 None
             }
-        };
-
-        // EC communication from OS is not stable enough yet,
-        // it can't be trusted to reliably flash the EC without risk of damage.
-        println!("Sorry, flashing EC from the OS is not supported yet.");
-        None
+        }
     };
 
     if let Some(data) = data {


### PR DESCRIPTION
Works well on Linux. It's disabled by the windows driver at the moment though.

No need to block it in this application, users could also use ectool.