### PR TITLE
MEC detection: Fail if permission denied

### DIFF
--- a/framework_lib/src/chromium_ec/portio.rs
+++ b/framework_lib/src/chromium_ec/portio.rs
@@ -100,7 +100,10 @@ fn init() -> bool {
     }
 
     // First try on MEC
-    portio_mec::init();
+    if !portio_mec::init() {
+        *init = Initialized::Failed;
+        return false;
+    }
     let ec_id = portio_mec::transfer_read(MEC_MEMMAP_OFFSET + EC_MEMMAP_ID, 2);
     if ec_id[0] == b'E' && ec_id[1] == b'C' {
         *init = Initialized::SucceededMec;
@@ -113,6 +116,7 @@ fn init() -> bool {
         let res = ioperm(EC_LPC_ADDR_HOST_ARGS as u64, 8 + 0xFF, 1);
         if res != 0 {
             error!("ioperm failed. portio driver is likely block by Linux kernel lockdown mode");
+            *init = Initialized::Failed;
             return false;
         }
 

--- a/framework_lib/src/chromium_ec/portio.rs
+++ b/framework_lib/src/chromium_ec/portio.rs
@@ -90,14 +90,6 @@ fn init() -> bool {
         Initialized::NotYet => {}
     }
 
-    // First try on MEC
-    portio_mec::init();
-    let ec_id = portio_mec::transfer_read(MEC_MEMMAP_OFFSET + EC_MEMMAP_ID, 2);
-    if ec_id[0] == b'E' && ec_id[1] == b'C' {
-        *init = Initialized::SucceededMec;
-        return true;
-    }
-
     // In Linux userspace has to first request access to ioports
     // TODO: Close these again after we're done
     #[cfg(target_os = "linux")]
@@ -106,6 +98,15 @@ fn init() -> bool {
         *init = Initialized::Failed;
         return false;
     }
+
+    // First try on MEC
+    portio_mec::init();
+    let ec_id = portio_mec::transfer_read(MEC_MEMMAP_OFFSET + EC_MEMMAP_ID, 2);
+    if ec_id[0] == b'E' && ec_id[1] == b'C' {
+        *init = Initialized::SucceededMec;
+        return true;
+    }
+
     #[cfg(target_os = "linux")]
     unsafe {
         // 8 for request/response header, 0xFF for response

--- a/framework_lib/src/chromium_ec/portio_mec.rs
+++ b/framework_lib/src/chromium_ec/portio_mec.rs
@@ -22,12 +22,20 @@ const _MEC_LPC_DATA_REGISTER1: u16 = 0x0805;
 const MEC_LPC_DATA_REGISTER2: u16 = 0x0806;
 const _MEC_LPC_DATA_REGISTER3: u16 = 0x0807;
 
-pub fn init() {
+pub fn init() -> bool {
     #[cfg(target_os = "linux")]
     unsafe {
-        ioperm(EC_LPC_ADDR_HOST_DATA as u64, 8, 1);
-        ioperm(MEC_LPC_ADDRESS_REGISTER0 as u64, 10, 1);
+        println!("Init MEC");
+        let res = ioperm(EC_LPC_ADDR_HOST_DATA as u64, 8, 1);
+        if res != 0 {
+            error!("ioperm failed. portio driver is likely block by Linux kernel lockdown mode");
+            return false;
+        }
+        let res = ioperm(MEC_LPC_ADDRESS_REGISTER0 as u64, 10, 1);
+        assert_eq!(res, 0);
     }
+
+    true
 }
 
 // TODO: Create a wrapper


### PR DESCRIPTION
Don't let it go through and possibly segfault.
Print an error for the user and exit.

Solved #153