### PR TITLE
--versions: Show any number of PD versions 

### DIFF
--- a/framework_lib/src/ccgx/mod.rs
+++ b/framework_lib/src/ccgx/mod.rs
@@ -3,6 +3,7 @@
 use alloc::format;
 use alloc::string::String;
 use alloc::string::ToString;
+use alloc::vec::Vec;
 #[cfg(feature = "uefi")]
 use core::prelude::rust_2021::derive;
 use num_derive::FromPrimitive;
@@ -241,9 +242,10 @@ pub struct PdVersions {
 
 /// Same as PdVersions but only the main FW
 #[derive(Debug)]
-pub struct MainPdVersions {
-    pub controller01: ControllerVersion,
-    pub controller23: ControllerVersion,
+pub enum MainPdVersions {
+    RightLeft((ControllerVersion, ControllerVersion)),
+    Single(ControllerVersion),
+    Many(Vec<ControllerVersion>),
 }
 
 pub fn get_pd_controller_versions(ec: &CrosEc) -> EcResult<PdVersions> {

--- a/framework_lib/src/ccgx/mod.rs
+++ b/framework_lib/src/ccgx/mod.rs
@@ -3,6 +3,7 @@
 use alloc::format;
 use alloc::string::String;
 use alloc::string::ToString;
+use alloc::vec;
 use alloc::vec::Vec;
 #[cfg(feature = "uefi")]
 use core::prelude::rust_2021::derive;
@@ -235,9 +236,10 @@ impl ControllerFirmwares {
 }
 
 #[derive(Debug, PartialEq)]
-pub struct PdVersions {
-    pub controller01: ControllerFirmwares,
-    pub controller23: ControllerFirmwares,
+pub enum PdVersions {
+    RightLeft((ControllerFirmwares, ControllerFirmwares)),
+    Single(ControllerFirmwares),
+    Many(Vec<ControllerFirmwares>),
 }
 
 /// Same as PdVersions but only the main FW
@@ -249,10 +251,17 @@ pub enum MainPdVersions {
 }
 
 pub fn get_pd_controller_versions(ec: &CrosEc) -> EcResult<PdVersions> {
-    Ok(PdVersions {
-        controller01: PdController::new(PdPort::Left01, ec.clone()).get_fw_versions()?,
-        controller23: PdController::new(PdPort::Right23, ec.clone()).get_fw_versions()?,
-    })
+    let pd01 = PdController::new(PdPort::Left01, ec.clone()).get_fw_versions();
+    let pd23 = PdController::new(PdPort::Right23, ec.clone()).get_fw_versions();
+    let pd_back = PdController::new(PdPort::Back, ec.clone()).get_fw_versions();
+
+    match (pd01, pd23, pd_back) {
+        (Err(_), Err(_), Ok(pd_back)) => Ok(PdVersions::Single(pd_back)),
+        (Ok(pd01), Ok(pd23), Err(_)) => Ok(PdVersions::RightLeft((pd01, pd23))),
+        (Ok(pd01), Ok(pd23), Ok(pd_back)) => Ok(PdVersions::Many(vec![pd01, pd23, pd_back])),
+        (Err(err), _, _) => Err(err),
+        (_, Err(err), _) => Err(err),
+    }
 }
 
 fn parse_metadata_ccg3(buffer: &[u8]) -> Option<(u32, u32)> {

--- a/framework_lib/src/chromium_ec/commands.rs
+++ b/framework_lib/src/chromium_ec/commands.rs
@@ -987,17 +987,37 @@ impl EcRequest<EcResponseChassisIntrusionControl> for EcRequestChassisIntrusionC
 }
 
 #[repr(C, packed)]
-pub struct EcRequestReadPdVersion {}
+pub struct EcRequestReadPdVersionV0 {}
 
 #[repr(C, packed)]
-pub struct _EcResponseReadPdVersion {
+pub struct _EcResponseReadPdVersionV0 {
     pub controller01: [u8; 8],
     pub controller23: [u8; 8],
 }
 
-impl EcRequest<_EcResponseReadPdVersion> for EcRequestReadPdVersion {
+impl EcRequest<_EcResponseReadPdVersionV0> for EcRequestReadPdVersionV0 {
     fn command_id() -> EcCommands {
         EcCommands::ReadPdVersion
+    }
+    fn command_version() -> u8 {
+        0
+    }
+}
+
+#[repr(C, packed)]
+pub struct EcRequestReadPdVersionV1 {}
+#[repr(C, packed)]
+pub struct _EcResponseReadPdVersionV1 {
+    pub pd_chip_count: u8,
+    pub pd_controllers: [u8; 0],
+}
+
+impl EcRequest<_EcResponseReadPdVersionV1> for EcRequestReadPdVersionV1 {
+    fn command_id() -> EcCommands {
+        EcCommands::ReadPdVersion
+    }
+    fn command_version() -> u8 {
+        1
     }
 }
 

--- a/framework_lib/src/commandline/mod.rs
+++ b/framework_lib/src/commandline/mod.rs
@@ -59,8 +59,7 @@ use crate::touchpad::print_touchpad_fw_ver;
 use crate::touchscreen;
 #[cfg(feature = "uefi")]
 use crate::uefi::enable_page_break;
-use crate::util;
-use crate::util::{Config, Platform, PlatformFamily};
+use crate::util::{self, Config, Platform, PlatformFamily};
 #[cfg(feature = "hidapi")]
 use hidapi::HidApi;
 use sha2::{Digest, Sha256, Sha384, Sha512};
@@ -557,7 +556,7 @@ fn print_versions(ec: &CrosEc) {
     }
 
     #[cfg(target_os = "linux")]
-    {
+    if smbios::get_platform().and_then(Platform::which_cpu_vendor) != Some(util::CpuVendor::Amd) {
         println!("CSME");
         if let Ok(csme) = csme::csme_from_sysfs() {
             info!("  Enabled:          {}", csme.enabled);

--- a/framework_lib/src/util.rs
+++ b/framework_lib/src/util.rs
@@ -49,7 +49,28 @@ pub enum PlatformFamily {
     FrameworkDesktop,
 }
 
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub enum CpuVendor {
+    Intel,
+    Amd,
+}
+
 impl Platform {
+    pub fn which_cpu_vendor(self) -> Option<CpuVendor> {
+        match self {
+            Platform::Framework12IntelGen13
+            | Platform::IntelGen11
+            | Platform::IntelGen12
+            | Platform::IntelGen13
+            | Platform::IntelCoreUltra1 => Some(CpuVendor::Intel),
+            Platform::Framework13Amd7080
+            | Platform::Framework13AmdAi300
+            | Platform::Framework16Amd7080
+            | Platform::FrameworkDesktopAmdAiMax300 => Some(CpuVendor::Amd),
+            Platform::GenericFramework(..) => None,
+            Platform::UnknownSystem => None,
+        }
+    }
     pub fn which_family(self) -> Option<PlatformFamily> {
         match self {
             Platform::Framework12IntelGen13 => Some(PlatformFamily::Framework12),


### PR DESCRIPTION
Not all systems have exactly 2 PD controllers, e.g. Framework Desktop has just 1.