### PR TITLE
chromium_ec: Erase EC in sections

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -464,3 +464,23 @@ ESRT Entry 0
   Last Attempt Version: 0x108 (264)
   Last Attempt Status:  Success
 ```
+
+## Flashing EC firmware
+
+**IMPORTANT** Flashing EC firmware yourself is not recommended. It may render
+your hardware unbootable. Please update your firmware using the official BIOS
+update methods (Windows .exe, LVFS/FWUPD, EFI updater)!
+
+This command has not been thoroughly tested on all Framework Computer systems
+
+```
+# Simulate flashing RW (to see which blocks are updated)
+> framework_tool --flash-rw-ec ec.bin --dry-run
+
+# Actually flash RW
+> framework_tool --flash-rw-ec ec.bin
+
+# Boot into EC RW firmware (will crash your OS and reboot immediately)
+# EC will boot back into RO if the system turned off for 30s
+> framework_tool --reboot-ec jump-rw
+```

--- a/framework_lib/src/chromium_ec/mod.rs
+++ b/framework_lib/src/chromium_ec/mod.rs
@@ -704,6 +704,7 @@ impl CrosEc {
     /// | 40000 | 3C000 | 39000 | RO Region   |
     /// | 79000 | 79FFF | 01000 | Flash Flags |
     pub fn reflash(&self, data: &[u8], ft: EcFlashType) -> EcResult<()> {
+        let mut res = Ok(());
         if ft == EcFlashType::Full || ft == EcFlashType::Ro {
             if let Some(version) = ec_binary::read_ec_version(data, true) {
                 println!("EC RO Version in File: {:?}", version.version);
@@ -753,7 +754,8 @@ impl CrosEc {
             if rw_data == flash_rw_data {
                 println!("  RW verify success");
             } else {
-                println!("RW verify fail");
+                error!("RW verify fail!");
+                res = Err(EcError::DeviceError("RW verify fail!".to_string()));
             }
         }
 
@@ -773,7 +775,8 @@ impl CrosEc {
             if ro_data == flash_ro_data {
                 println!("  RO verify success");
             } else {
-                println!("RO verify fail");
+                error!("RO verify fail!");
+                res = Err(EcError::DeviceError("RW verify fail!".to_string()));
             }
         }
 
@@ -785,7 +788,7 @@ impl CrosEc {
             println!("Flashing EC done. You can reboot the EC now");
         }
 
-        Ok(())
+        res
     }
 
     /// Write a big section of EC flash. Must be unlocked already

--- a/framework_lib/src/commandline/clap_std.rs
+++ b/framework_lib/src/commandline/clap_std.rs
@@ -123,11 +123,11 @@ struct ClapCli {
     #[arg(long)]
     dump_ec_flash: Option<std::path::PathBuf>,
 
-    /// Flash EC with new firmware from file
+    /// Flash EC (RO+RW) with new firmware from file - may render your hardware unbootable!
     #[arg(long)]
     flash_ec: Option<std::path::PathBuf>,
 
-    /// Flash EC with new RO firmware from file
+    /// Flash EC with new RO firmware from file - may render your hardware unbootable!
     #[arg(long)]
     flash_ro_ec: Option<std::path::PathBuf>,
 
@@ -250,6 +250,14 @@ struct ClapCli {
     /// Run self-test to check if interaction with EC is possible
     #[arg(long, short)]
     test: bool,
+
+    /// Force execution of an unsafe command - may render your hardware unbootable!
+    #[arg(long, short)]
+    force: bool,
+
+    /// Simulate execution of a command (e.g. --flash-ec)
+    #[arg(long)]
+    dry_run: bool,
 }
 
 /// Parse a list of commandline arguments and return the struct
@@ -424,6 +432,8 @@ pub fn parse(args: &[String]) -> Cli {
         pd_addrs,
         pd_ports,
         test: args.test,
+        dry_run: args.dry_run,
+        force: args.force,
         // TODO: Set help. Not very important because Clap handles this by itself
         help: false,
         // UEFI only for now. Don't need to handle

--- a/framework_lib/src/commandline/uefi.rs
+++ b/framework_lib/src/commandline/uefi.rs
@@ -109,6 +109,8 @@ pub fn parse(args: &[String]) -> Cli {
         pd_addrs: None,
         pd_ports: None,
         test: false,
+        dry_run: false,
+        force: false,
         help: false,
         flash_gpu_descriptor: None,
         allupdate: false,
@@ -503,6 +505,12 @@ pub fn parse(args: &[String]) -> Cli {
             found_an_option = true;
         } else if arg == "-t" || arg == "--test" {
             cli.test = true;
+            found_an_option = true;
+        } else if arg == "-f" || arg == "--force" {
+            cli.force = true;
+            found_an_option = true;
+        } else if arg == "--dry-run" {
+            cli.dry_run = true;
             found_an_option = true;
         } else if arg == "-h" || arg == "--help" {
             cli.help = true;


### PR DESCRIPTION
Erasing a big section takes too long sometimes and the linux kernel driver times out, so split it up into chunks.