### PR TITLE
fw16: add command to write and read expansion bay eeprom

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -317,7 +317,12 @@ Expansion Bay
   Serial Number: FRAXXXXXXXXXXXXXXX
   Config:        Pcie4x2
   Vendor:        SsdHolder
+  Expansion Bay EEPROM
+    Valid:       true
+    HW Version:  8.0
 ```
+
+Add `-vv` for more verbose details.
 
 ## Check charger and battery status (Framework 12/13/16)
 

--- a/EXAMPLES_ADVANCED.md
+++ b/EXAMPLES_ADVANCED.md
@@ -87,6 +87,11 @@ It's intended for advanced users who build their own expansion bay module.
 The I2C address of the EEPROM is hardcoded to 0x50.
 
 ```
+# Dump current descriptor (e.g. for backup)
+> framework_tool --dump-gpu-descriptor-file foo.bin
+Dumping to foo.bin
+Wrote 153 bytes to foo.bin
+
 # Update just the serial number
 > framework_tool --flash_gpu_descriptor GPU FRAKMQCP41500ASSY1
 > framework_tool --flash_gpu_descriptor 13 FRAKMQCP41500ASSY1

--- a/EXAMPLES_ADVANCED.md
+++ b/EXAMPLES_ADVANCED.md
@@ -79,3 +79,19 @@ This command has not been thoroughly tested on all Framework Computer systems
 # EC will boot back into RO if the system turned off for 30s
 > framework_tool --reboot-ec jump-rw
 ```
+
+## Flashing Expansion Bay EEPROM (Framework 16)
+
+This will render your dGPU unsuable if you flash the wrong file!
+It's intended for advanced users who build their own expansion bay module.
+The I2C address of the EEPROM is hardcoded to 0x50.
+
+```
+# Update just the serial number
+> framework_tool --flash_gpu_descriptor GPU FRAKMQCP41500ASSY1
+> framework_tool --flash_gpu_descriptor 13 FRAKMQCP41500ASSY1
+> framework_tool --flash_gpu_descriptor 0x0D FRAKMQCP41500ASSY1
+
+# Update everything from a file
+> framework_tool --flash-gpu-descriptor-file pcie_4x2.bin
+```

--- a/framework_lib/src/chromium_ec/mod.rs
+++ b/framework_lib/src/chromium_ec/mod.rs
@@ -1177,6 +1177,34 @@ impl CrosEc {
         Ok(result.valid)
     }
 
+    pub fn read_ec_gpu_chunk(&self, addr: u16, len: u16) -> EcResult<Vec<u8>> {
+        let eeprom_port = 0x05;
+        let eeprom_addr = 0x50;
+        let mut data: Vec<u8> = Vec::with_capacity(len.into());
+
+        while data.len() < len.into() {
+            let remaining = len - data.len() as u16;
+            let chunk_len = std::cmp::min(i2c_passthrough::MAX_I2C_CHUNK, remaining.into());
+            let offset = addr + data.len() as u16;
+            let i2c_response = i2c_passthrough::i2c_read(
+                self,
+                eeprom_port,
+                eeprom_addr,
+                offset,
+                chunk_len as u16,
+            )?;
+            if let Err(EcError::DeviceError(err)) = i2c_response.is_successful() {
+                return Err(EcError::DeviceError(format!(
+                    "I2C read was not successful: {:?}",
+                    err
+                )));
+            }
+            data.extend(i2c_response.data);
+        }
+
+        Ok(data)
+    }
+
     pub fn write_ec_gpu_chunk(&self, offset: u16, data: &[u8]) -> EcResult<()> {
         let result = i2c_passthrough::i2c_write(self, 5, 0x50, offset, data)?;
         result.is_successful()
@@ -1224,6 +1252,15 @@ impl CrosEc {
         }
         println!();
         Ok(())
+    }
+
+    pub fn read_gpu_desc_header(&self) -> EcResult<GpuCfgDescriptor> {
+        let bytes =
+            self.read_ec_gpu_chunk(0x00, core::mem::size_of::<GpuCfgDescriptor>() as u16)?;
+        let header: *const GpuCfgDescriptor = unsafe { std::mem::transmute(bytes.as_ptr()) };
+        let header = unsafe { *header };
+
+        Ok(header)
     }
 
     /// Requests recent console output from EC and constantly asks for more
@@ -1632,4 +1669,29 @@ pub struct IntrusionStatus {
     /// We can tell because opening the chassis, even when off, leaves a sticky bit that the EC can read when it powers back on.
     /// That means we only know if it was opened at least once, while off, not how many times.
     pub vtr_open_count: u8,
+}
+
+#[derive(Clone, Debug, Copy, PartialEq)]
+#[repr(C, packed)]
+pub struct GpuCfgDescriptor {
+    /// Expansion bay card magic value that is unique
+    pub magic: [u8; 4],
+    /// Length of header following this field
+    pub length: u32,
+    /// descriptor version, if EC max version is lower than this, ec cannot parse
+    pub desc_ver_major: u16,
+    pub desc_ver_minor: u16,
+    /// Hardware major version
+    pub hardware_version: u16,
+    /// Hardware minor revision
+    pub hardware_revision: u16,
+    /// 18 digit Framework Serial that starts with FRA
+    /// the first 10 digits must be allocated by framework
+    pub serial: [u8; 20],
+    /// Length of descriptor following heade
+    pub descriptor_length: u32,
+    /// CRC of descriptor
+    pub descriptor_crc32: u32,
+    /// CRC of header before this value
+    pub crc32: u32,
 }

--- a/framework_lib/src/chromium_ec/mod.rs
+++ b/framework_lib/src/chromium_ec/mod.rs
@@ -1254,6 +1254,16 @@ impl CrosEc {
         Ok(())
     }
 
+    pub fn read_gpu_descriptor(&self) -> EcResult<Vec<u8>> {
+        let header = self.read_gpu_desc_header()?;
+        if header.magic != [0x32, 0xAC, 0x00, 0x00] {
+            return Err(EcError::DeviceError(
+                "Invalid descriptor hdr magic".to_string(),
+            ));
+        }
+        self.read_ec_gpu_chunk(0x00, header.descriptor_length as u16)
+    }
+
     pub fn read_gpu_desc_header(&self) -> EcResult<GpuCfgDescriptor> {
         let bytes =
             self.read_ec_gpu_chunk(0x00, core::mem::size_of::<GpuCfgDescriptor>() as u16)?;

--- a/framework_lib/src/chromium_ec/mod.rs
+++ b/framework_lib/src/chromium_ec/mod.rs
@@ -1183,7 +1183,11 @@ impl CrosEc {
     }
 
     /// Writes EC GPU descriptor to the GPU EEPROM.
-    pub fn set_gpu_descriptor(&self, data: &[u8]) -> EcResult<()> {
+    pub fn set_gpu_descriptor(&self, data: &[u8], dry_run: bool) -> EcResult<()> {
+        println!(
+            "Writing GPU EEPROM {}",
+            if dry_run { " (DRY RUN)" } else { "" }
+        );
         // Need to program the EEPROM 32 bytes at a time.
         let chunk_size = 32;
 
@@ -1204,6 +1208,9 @@ impl CrosEc {
                 );
             } else {
                 print!("X");
+            }
+            if dry_run {
+                continue;
             }
 
             let chunk = &data[offset..offset + cur_chunk_size];

--- a/framework_lib/src/chromium_ec/mod.rs
+++ b/framework_lib/src/chromium_ec/mod.rs
@@ -1214,8 +1214,7 @@ impl CrosEc {
             }
 
             let chunk = &data[offset..offset + cur_chunk_size];
-            let offset_le = (((offset as u16) << 8) & 0xff00) | (((offset as u16) >> 8) & 0x00ff);
-            let res = self.write_ec_gpu_chunk(offset_le, chunk);
+            let res = self.write_ec_gpu_chunk((offset as u16).to_be(), chunk);
             // Don't read too fast, wait 100ms before writing more to allow for page erase/write cycle.
             os_specific::sleep(100_000);
             if let Err(err) = res {

--- a/framework_lib/src/commandline/clap_std.rs
+++ b/framework_lib/src/commandline/clap_std.rs
@@ -274,6 +274,10 @@ struct ClapCli {
     /// File to write to the gpu EEPROM
     #[arg(long)]
     flash_gpu_descriptor_file: Option<std::path::PathBuf>,
+
+    /// File to dump the gpu EEPROM to
+    #[arg(long)]
+    dump_gpu_descriptor_file: Option<std::path::PathBuf>,
 }
 
 /// Parse a list of commandline arguments and return the struct
@@ -463,6 +467,9 @@ pub fn parse(args: &[String]) -> Cli {
         flash_gpu_descriptor,
         flash_gpu_descriptor_file: args
             .flash_gpu_descriptor_file
+            .map(|x| x.into_os_string().into_string().unwrap()),
+        dump_gpu_descriptor_file: args
+            .dump_gpu_descriptor_file
             .map(|x| x.into_os_string().into_string().unwrap()),
         raw_command: vec![],
     }

--- a/framework_lib/src/commandline/clap_std.rs
+++ b/framework_lib/src/commandline/clap_std.rs
@@ -270,6 +270,10 @@ struct ClapCli {
     /// Simulate execution of a command (e.g. --flash-ec)
     #[arg(long)]
     dry_run: bool,
+
+    /// File to write to the gpu EEPROM
+    #[arg(long)]
+    flash_gpu_descriptor_file: Option<std::path::PathBuf>,
 }
 
 /// Parse a list of commandline arguments and return the struct
@@ -457,6 +461,9 @@ pub fn parse(args: &[String]) -> Cli {
         paginate: false,
         info: args.info,
         flash_gpu_descriptor,
+        flash_gpu_descriptor_file: args
+            .flash_gpu_descriptor_file
+            .map(|x| x.into_os_string().into_string().unwrap()),
         raw_command: vec![],
     }
 }

--- a/framework_lib/src/commandline/mod.rs
+++ b/framework_lib/src/commandline/mod.rs
@@ -884,6 +884,26 @@ pub fn run_with_args(args: &Cli, _allupdate: bool) -> i32 {
         if let Err(err) = ec.check_bay_status() {
             error!("{:?}", err);
         }
+        if let Ok(header) = ec.read_gpu_desc_header() {
+            println!("  Expansion Bay EEPROM");
+            println!(
+                "    Valid:       {:?}",
+                header.magic == [0x32, 0xAC, 0x00, 0x00]
+            );
+            println!("    HW Version:  {}.{}", { header.hardware_version }, {
+                header.hardware_revision
+            });
+            if log_enabled!(Level::Info) {
+                println!("    Hdr Length   {} B", { header.length });
+                println!("    Desc Ver:    {}.{}", { header.desc_ver_major }, {
+                    header.desc_ver_minor
+                });
+                println!("    Serialnumber:{:X?}", { header.serial });
+                println!("    Desc Length: {} B", { header.descriptor_length });
+                println!("    Desc CRC:    {:X}", { header.descriptor_crc32 });
+                println!("    Hdr CRC:     {:X}", { header.crc32 });
+            }
+        }
     } else if let Some(maybe_limit) = args.charge_limit {
         print_err(handle_charge_limit(&ec, maybe_limit));
     } else if let Some((limit, soc)) = args.charge_current_limit {

--- a/framework_lib/src/commandline/mod.rs
+++ b/framework_lib/src/commandline/mod.rs
@@ -1240,7 +1240,7 @@ pub fn run_with_args(args: &Cli, _allupdate: bool) -> i32 {
                 println!("File");
                 println!("  Size:       {:>20} B", data.len());
                 println!("  Size:       {:>20} KB", data.len() / 1024);
-                let res = ec.set_gpu_descriptor(&data);
+                let res = ec.set_gpu_descriptor(&data, args.dry_run);
                 match res {
                     Ok(()) => println!("GPU Descriptor successfully written"),
                     Err(err) => println!("GPU Descriptor write failed with error:  {:?}", err),

--- a/framework_lib/src/commandline/mod.rs
+++ b/framework_lib/src/commandline/mod.rs
@@ -1222,9 +1222,10 @@ pub fn run_with_args(args: &Cli, _allupdate: bool) -> i32 {
             Err(err) => println!("GPU Descriptor write failed with error:  {:?}", err),
         }
     } else if let Some(gpu_descriptor_file) = &args.flash_gpu_descriptor_file {
-        if let Some(PlatformFamily::Framework16) =
-            smbios::get_platform().and_then(Platform::which_family)
-        {
+        if matches!(
+            smbios::get_family(),
+            Some(PlatformFamily::Framework16) | None
+        ) {
             #[cfg(feature = "uefi")]
             let data: Option<Vec<u8>> = crate::uefi::fs::shell_read_file(gpu_descriptor_file);
             #[cfg(not(feature = "uefi"))]

--- a/framework_lib/src/commandline/uefi.rs
+++ b/framework_lib/src/commandline/uefi.rs
@@ -116,6 +116,7 @@ pub fn parse(args: &[String]) -> Cli {
         force: false,
         help: false,
         flash_gpu_descriptor: None,
+        flash_gpu_descriptor_file: None,
         allupdate: false,
         info: false,
         raw_command: vec![],
@@ -761,6 +762,14 @@ pub fn parse(args: &[String]) -> Cli {
                 }
             } else {
                 println!("Need to provide a value for --flash_gpu_descriptor. TYPE_MAGIC SERIAL");
+                None
+            };
+            found_an_option = true;
+        } else if arg == "--flash-gpu-descriptor-file" {
+            cli.flash_gpu_descriptor_file = if args.len() > i + 1 {
+                Some(args[i + 1].clone())
+            } else {
+                println!("Need to provide a value for --flash_gpu_descriptor_file. PATH");
                 None
             };
             found_an_option = true;

--- a/framework_lib/src/commandline/uefi.rs
+++ b/framework_lib/src/commandline/uefi.rs
@@ -117,6 +117,7 @@ pub fn parse(args: &[String]) -> Cli {
         help: false,
         flash_gpu_descriptor: None,
         flash_gpu_descriptor_file: None,
+        dump_gpu_descriptor_file: None,
         allupdate: false,
         info: false,
         raw_command: vec![],
@@ -770,6 +771,14 @@ pub fn parse(args: &[String]) -> Cli {
                 Some(args[i + 1].clone())
             } else {
                 println!("Need to provide a value for --flash_gpu_descriptor_file. PATH");
+                None
+            };
+            found_an_option = true;
+        } else if arg == "--dump-gpu-descriptor-file" {
+            cli.dump_gpu_descriptor_file = if args.len() > i + 1 {
+                Some(args[i + 1].clone())
+            } else {
+                println!("Need to provide a value for --dump_gpu_descriptor_file. PATH");
                 None
             };
             found_an_option = true;


### PR DESCRIPTION
from a file

Example invocation:

boot.efi --flash-gpu-descriptor-file pcie_4x2.bin

TEST=fail: if the write fails we will error correctly TEST=pass: the command will succeed.
TEST=dump contents using ec console:
i2c read I2C_PORT5 0x50 0x0000 16
00000000: 32 ac 00 00 30 00 00 00  00 00 01 00 08 00 00 00 |2...0... ........| And compare to xxd dump of source file to ensure they match.