### PR TITLE
--versions: Add OS and tool version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,6 +435,7 @@ dependencies = [
  "uefi",
  "uefi-services",
  "windows 0.59.0",
+ "windows-version",
  "wmi",
 ]
 
@@ -1560,6 +1561,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
 name = "windows-result"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1640,6 +1647,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.0",
  "windows_x86_64_gnullvm 0.53.0",
  "windows_x86_64_msvc 0.53.0",
+]
+
+[[package]]
+name = "windows-version"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e04a5c6627e310a23ad2358483286c7df260c964eb2d003d8efd6d0f4e79265c"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/framework_lib/Cargo.toml
+++ b/framework_lib/Cargo.toml
@@ -49,6 +49,7 @@ env_logger = "0.11"
 clap = { version = "4.5", features = ["derive", "cargo"] }
 clap-num = { version = "1.2.0" }
 clap-verbosity-flag = { version = "2.2.1" }
+windows-version = "0.1.4"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.155"

--- a/framework_lib/src/commandline/mod.rs
+++ b/framework_lib/src/commandline/mod.rs
@@ -49,6 +49,7 @@ use crate::ec_binary;
 use crate::esrt;
 #[cfg(feature = "rusb")]
 use crate::inputmodule::check_inputmodule_version;
+use crate::os_specific;
 use crate::power;
 use crate::smbios;
 use crate::smbios::ConfigDigit0;
@@ -374,6 +375,8 @@ fn print_stylus_battery_level() {
 }
 
 fn print_versions(ec: &CrosEc) {
+    println!("Tool Version:     {}", built_info::PKG_VERSION);
+    println!("OS Version:       {}", os_specific::get_os_version());
     println!("Mainboard Hardware");
     if let Some(ver) = smbios::get_product_name() {
         println!("  Type:           {}", ver);

--- a/framework_lib/src/os_specific.rs
+++ b/framework_lib/src/os_specific.rs
@@ -3,6 +3,39 @@
 #[cfg(not(feature = "uefi"))]
 use std::{thread, time};
 
+#[cfg(feature = "uefi")]
+use alloc::string::{String, ToString};
+
+// Could report the implemented UEFI spec version
+// But that's not very useful. Just look at the BIOS version
+// But at least it's useful to see that the tool was run on UEFI
+#[cfg(feature = "uefi")]
+pub fn get_os_version() -> String {
+    "UEFI".to_string()
+}
+
+#[cfg(target_family = "windows")]
+pub fn get_os_version() -> String {
+    let ver = windows_version::OsVersion::current();
+    format!("{}.{}.{}.{}", ver.major, ver.minor, ver.pack, ver.build)
+}
+
+#[cfg(target_family = "unix")]
+pub fn get_os_version() -> String {
+    if let Ok(uts) = nix::sys::utsname::uname() {
+        // uname -a without hostname
+        format!(
+            "{} {} {} {}",
+            uts.sysname().to_string_lossy(),
+            uts.release().to_string_lossy(),
+            uts.version().to_string_lossy(),
+            uts.machine().to_string_lossy(),
+        )
+    } else {
+        "Unknown".to_string()
+    }
+}
+
 /// Sleep a number of microseconds
 pub fn sleep(micros: u64) {
     #[cfg(not(feature = "uefi"))]


### PR DESCRIPTION
It's useful to know which Linux/FreeBSD kernel or windows version people are running when reporting an issue.

Example:                                                                                                                                    
                                                                                                                                            
```
> sudo framework_tool --versions
Tool Version:     0.4.3
OS Version:       Linux 6.15.1 #1-NixOS SMP PREEMPT_DYNAMIC Wed Jun  4 12:46:27 UTC 2025 x86_64
```