### PR TITLE
--inputdeck: On FW16 also print sleep_l gpio state

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -234,6 +234,7 @@ Input Deck
 Chassis Closed:   true
 Input Deck State: On
 Touchpad present: true
+SLEEP# GPIO high: true
 Positions:
   Pos 0: GenericC
   Pos 1: KeyboardA

--- a/framework_lib/src/chromium_ec/mod.rs
+++ b/framework_lib/src/chromium_ec/mod.rs
@@ -603,9 +603,11 @@ impl CrosEc {
     pub fn print_fw16_inputdeck_status(&self) -> EcResult<()> {
         let intrusion = self.get_intrusion_status()?;
         let status = self.get_input_deck_status()?;
+        let sleep_l = self.get_gpio("sleep_l")?;
         println!("Chassis Closed:   {}", !intrusion.currently_open);
         println!("Input Deck State: {:?}", status.state);
         println!("Touchpad present: {}", status.touchpad_present);
+        println!("SLEEP# GPIO high: {}", sleep_l);
         println!("Positions:");
         println!("  Pos 0: {:?}", status.top_row.pos0);
         println!("  Pos 1: {:?}", status.top_row.pos1);


### PR DESCRIPTION
To help debug keyboard/EC issues it's useful to know what the state of that GPIO is. EC uses it to tell the keyboard about system sleep and lid state.

```
> framework_tool --inputdeck
Chassis Closed:   true
Input Deck State: On
Touchpad present: true
SLEEP# GPIO high: true
Positions:
  Pos 0: KeyboardA
  Pos 1: Disconnected
  Pos 2: Disconnected
  Pos 3: KeyboardB
  Pos 4: Disconnected
```