### PR TITLE
uefi: Fix shell args when run from a script

### DIFF
--- a/framework_uefi/Makefile
+++ b/framework_uefi/Makefile
@@ -38,6 +38,9 @@ $(BUILD)/efi.img: $(BUILD)/boot.efi
 	mkfs.vfat $@.tmp
 	mmd -i $@.tmp efi
 	mmd -i $@.tmp efi/boot
+	echo 'efi\boot\bootx64.efi --version' > startup.nsh
+	mcopy -i $@.tmp startup.nsh ::efi/boot/startup.nsh
+	rm -f startup.nsh
 	mcopy -i $@.tmp $< ::efi/boot/bootx64.efi
 	mv $@.tmp $@
 

--- a/framework_uefi/src/main.rs
+++ b/framework_uefi/src/main.rs
@@ -12,11 +12,11 @@ extern crate alloc;
 use framework_lib::commandline;
 
 #[entry]
-fn main(_handle: Handle, mut system_table: SystemTable<Boot>) -> Status {
+fn main(image_handle: Handle, mut system_table: SystemTable<Boot>) -> Status {
     uefi_services::init(&mut system_table).unwrap();
     let bs = system_table.boot_services();
 
-    let args = commandline::uefi::get_args(bs);
+    let args = commandline::uefi::get_args(bs, image_handle);
     let args = commandline::parse(&args);
     if commandline::run_with_args(&args, false) == 0 {
         return Status::SUCCESS;


### PR DESCRIPTION
The UEFI tool wouldn't get any arugments when run from a UEFI shell
script. Manually runnning from the shell would work, but not from e.g.
startup.nsh