### PR TITLE
chore: send errors to stderr

### DIFF
--- a/framework_lib/src/capsule.rs
+++ b/framework_lib/src/capsule.rs
@@ -185,7 +185,7 @@ pub fn dump_winux_image(data: &[u8], header: &DisplayCapsule, filename: &str) {
     {
         let ret = crate::uefi::fs::shell_write_file(filename, image);
         if let Err(err) = ret {
-            println!("Failed to dump winux image: {:?}", err);
+            eprintln!("Failed to dump winux image: {:?}", err);
         }
     }
 }

--- a/framework_lib/src/ccgx/hid.rs
+++ b/framework_lib/src/ccgx/hid.rs
@@ -290,7 +290,7 @@ pub fn flash_firmware(fw_binary: &[u8]) {
     let versions = if let Some(versions) = ccgx::binary::read_versions(fw_binary, SiliconId::Ccg3) {
         versions
     } else {
-        println!("Incompatible firmware. Need CCG3 firmware.");
+        eprintln!("Incompatible firmware. Need CCG3 firmware.");
         return;
     };
 
@@ -302,7 +302,7 @@ pub fn flash_firmware(fw_binary: &[u8]) {
     } else if util::find_sequence(fw_binary, dp_string).is_some() {
         [DP_CARD_PID]
     } else {
-        println!("Incompatible firmware. Need DP/HDMI Expansion Card Firmware.");
+        eprintln!("Incompatible firmware. Need DP/HDMI Expansion Card Firmware.");
         return;
     };
 
@@ -319,7 +319,7 @@ pub fn flash_firmware(fw_binary: &[u8]) {
     let mut api = HidApi::new().unwrap();
     let devices = find_devices(&api, &filter_devs, None);
     if devices.is_empty() {
-        println!("No compatible Expansion Card connected");
+        eprintln!("No compatible Expansion Card connected");
         return;
     };
     for dev_info in devices {

--- a/framework_lib/src/ccgx/mod.rs
+++ b/framework_lib/src/ccgx/mod.rs
@@ -302,7 +302,7 @@ fn parse_metadata_cyacd2(buffer: &[u8]) -> Option<(u32, u32)> {
         if metadata.metadata_version == 1 {
             Some((metadata.fw_start, metadata.fw_size))
         } else {
-            println!("Unknown CCG8 metadata version");
+            eprintln!("Unknown CCG8 metadata version");
             None
         }
     } else {

--- a/framework_lib/src/chromium_ec/cros_ec.rs
+++ b/framework_lib/src/chromium_ec/cros_ec.rs
@@ -79,7 +79,7 @@ fn init() {
         return;
     }
     match std::fs::File::open(DEV_PATH) {
-        Err(why) => println!("Failed to open {}. Because: {:?}", DEV_PATH, why),
+        Err(why) => eprintln!("Failed to open {}. Because: {:?}", DEV_PATH, why),
         Ok(file) => *device = Some(file),
     };
     // 2. Read max 80 bytes and check if equal to "1.0.0"

--- a/framework_lib/src/chromium_ec/mod.rs
+++ b/framework_lib/src/chromium_ec/mod.rs
@@ -855,7 +855,7 @@ impl CrosEc {
             if !dry_run {
                 let res = self.write_ec_flash_chunk(addr + offset as u32, chunk);
                 if let Err(err) = res {
-                    println!("  Failed to write chunk: {:?}", err);
+                    eprintln!("  Failed to write chunk: {:?}", err);
                     return Err(err);
                 }
             }
@@ -942,7 +942,7 @@ impl CrosEc {
                 // TODO: We don't want to crash here. But returning no data doesn't seem optimal
                 // either
                 // return Err(EcError::DeviceError("Execution interrupted".to_string()));
-                println!("Execution interrupted");
+                eprintln!("Execution interrupted");
                 return Ok(vec![]);
             }
 
@@ -1022,7 +1022,7 @@ impl CrosEc {
         // TODO: Does zephyr always start like this?
         let zephyr_start = [0x5E, 0x4D, 0x3B, 0x2A];
         if data[0..4] != legacy_start && data[0..4] != zephyr_start {
-            println!("      INVALID start");
+            eprintln!("      INVALID start");
             res = Err(EcError::DeviceError("INVALID start".to_string()));
         }
         // Legacy EC is all 0xFF until the end of the row
@@ -1030,7 +1030,7 @@ impl CrosEc {
         let legacy_comp = !data[4..].iter().all(|x| *x == 0xFF);
         let zephyr_comp = !data[0x20..0x40].iter().all(|x| *x == 0x00);
         if legacy_comp && zephyr_comp {
-            println!("      INVALID end");
+            eprintln!("      INVALID end");
             res = Err(EcError::DeviceError("INVALID end".to_string()));
         }
 
@@ -1055,13 +1055,13 @@ impl CrosEc {
         // let legacy_start = []; // TODO
         // let zephyr_start = [0x80, 0x7D, 0x0C, 0x20];
         // if data[0..4] != legacy_start && data[0..4] != zephyr_start {
-        //     println!("      INVALID start");
+        //     eprintln!("      INVALID start");
         //     res = Err(EcError::DeviceError("INVALID start".to_string()));
         // }
         // let legacy_comp = !data[4..].iter().all(|x| *x == 0xFF);
         // let zephyr_comp = !data[0x20..0x2C].iter().all(|x| *x == 0x00);
         // if legacy_comp && zephyr_comp {
-        //     println!("      INVALID end");
+        //     eprintln!("      INVALID end");
         //     res = Err(EcError::DeviceError("INVALID end".to_string()));
         // }
 
@@ -1104,7 +1104,7 @@ impl CrosEc {
             println!("      Erased flash flags");
             res = Err(EcError::DeviceError("Erased flash flags".to_string()));
         } else {
-            println!("      INVALID flash flags: {:02X?}", &data[0..12]);
+            eprintln!("      INVALID flash flags: {:02X?}", &data[0..12]);
             // TODO: Disable error until I confirm flash flags on MEC
             // res = Err(EcError::DeviceError("INVALID flash flags".to_string()));
         }
@@ -1248,7 +1248,7 @@ impl CrosEc {
             // Don't read too fast, wait 100ms before writing more to allow for page erase/write cycle.
             os_specific::sleep(100_000);
             if let Err(err) = res {
-                println!("  Failed to write chunk: {:?}", err);
+                eprintln!("  Failed to write chunk: {:?}", err);
                 return Err(err);
             }
         }

--- a/framework_lib/src/chromium_ec/windows.rs
+++ b/framework_lib/src/chromium_ec/windows.rs
@@ -55,9 +55,9 @@ fn init() -> bool {
                 | Some(platform @ Platform::IntelGen13)
                 | Some(platform @ Platform::Framework13Amd7080)
                 | Some(platform @ Platform::Framework16Amd7080) => {
-                    println!("The windows driver is not enabled on {:?}.", platform);
-                    println!("Please stay tuned for future BIOS and driver updates.");
-                    println!();
+                    eprintln!("The windows driver is not enabled on {:?}.", platform);
+                    eprintln!("Please stay tuned for future BIOS and driver updates.");
+                    eprintln!();
                 }
                 _ => (),
             }

--- a/framework_lib/src/commandline/mod.rs
+++ b/framework_lib/src/commandline/mod.rs
@@ -311,14 +311,14 @@ fn print_single_pd_details(pd: &PdController) {
     if let Ok(si) = pd.get_silicon_id() {
         println!("  Silicon ID:     0x{:X}", si);
     } else {
-        println!("  Failed to read Silicon ID/Family");
+        eprintln!("  Failed to read Silicon ID/Family");
         return;
     }
     if let Ok((mode, frs)) = pd.get_device_info() {
         println!("  Mode:           {:?}", mode);
         println!("  Flash Row Size: {} B", frs);
     } else {
-        println!("  Failed to device info");
+        eprintln!("  Failed to device info");
     }
     if let Ok(port_mask) = pd.get_port_status() {
         let ports = match port_mask {
@@ -336,7 +336,7 @@ fn print_single_pd_details(pd: &PdController) {
 
 fn print_pd_details(ec: &CrosEc) {
     if !is_framework() {
-        println!("Only supported on Framework systems");
+        eprintln!("Only supported on Framework systems");
         return;
     }
     let pd_01 = PdController::new(PdPort::Right01, ec.clone());
@@ -430,7 +430,7 @@ fn flash_dp_hdmi_card(pd_bin_path: &str) {
         Ok(data) => Some(data),
         // TODO: Perhaps a more user-friendly error
         Err(e) => {
-            println!("Error {:?}", e);
+            eprintln!("Error {:?}", e);
             None
         }
     };
@@ -728,7 +728,7 @@ fn print_esrt() {
     if let Some(esrt) = esrt::get_esrt() {
         esrt::print_esrt(&esrt);
     } else {
-        println!("Could not find and parse ESRT table.");
+        eprintln!("Could not find and parse ESRT table.");
     }
 }
 
@@ -741,7 +741,7 @@ fn flash_ec(ec: &CrosEc, ec_bin_path: &str, flash_type: EcFlashType, dry_run: bo
             Ok(data) => Some(data),
             // TODO: Perhaps a more user-friendly error
             Err(e) => {
-                println!("Error {:?}", e);
+                eprintln!("Error {:?}", e);
                 None
             }
         }
@@ -752,7 +752,7 @@ fn flash_ec(ec: &CrosEc, ec_bin_path: &str, flash_type: EcFlashType, dry_run: bo
         println!("  Size:       {:>20} B", data.len());
         println!("  Size:       {:>20} KB", data.len() / 1024);
         if let Err(err) = ec.reflash(&data, flash_type, dry_run) {
-            println!("Error: {:?}", err);
+            eprintln!("Error: {:?}", err);
         } else {
             println!("Success!");
         }
@@ -771,7 +771,7 @@ fn dump_ec_flash(ec: &CrosEc, dump_path: &str) {
     {
         let ret = crate::uefi::fs::shell_write_file(dump_path, &flash_bin);
         if ret.is_err() {
-            println!("Failed to dump EC FW image.");
+            eprintln!("Failed to dump EC FW image.");
         }
     }
 }
@@ -788,7 +788,7 @@ fn dump_dgpu_eeprom(ec: &CrosEc, dump_path: &str) {
     {
         let ret = crate::uefi::fs::shell_write_file(dump_path, &flash_bin);
         if ret.is_err() {
-            println!("Failed to dump EC FW image.");
+            eprintln!("Failed to dump EC FW image.");
         }
     }
     println!("Wrote {} bytes to {}", flash_bin.len(), dump_path);
@@ -936,7 +936,7 @@ pub fn run_with_args(args: &Cli, _allupdate: bool) -> i32 {
         if let Some(driver) = CrosEc::with(driver) {
             driver
         } else {
-            println!("Selected driver {:?} not available.", driver);
+            eprintln!("Selected driver {:?} not available.", driver);
             return 1;
         }
     } else {
@@ -1062,7 +1062,7 @@ pub fn run_with_args(args: &Cli, _allupdate: bool) -> i32 {
         print_err(ec.remap_key(row, col, scanset));
     } else if !args.rgbkbd.is_empty() {
         if args.rgbkbd.len() < 2 {
-            println!(
+            eprintln!(
                 "Must provide at least 2 arguments. Provided only: {}",
                 args.rgbkbd.len()
             );
@@ -1102,30 +1102,30 @@ pub fn run_with_args(args: &Cli, _allupdate: bool) -> i32 {
             }
             ConsoleArg::Recent => match ec.console_read_one() {
                 Ok(output) => println!("{}", output),
-                Err(err) => println!("Failed to read console: {:?}", err),
+                Err(err) => eprintln!("Failed to read console: {:?}", err),
             },
         }
     } else if let Some(reboot_arg) = &args.reboot_ec {
         match reboot_arg {
             RebootEcArg::Reboot => match ec.reboot_ec(RebootEcCmd::ColdReboot) {
                 Ok(_) => {}
-                Err(err) => println!("Failed: {:?}", err),
+                Err(err) => eprintln!("Failed: {:?}", err),
             },
             RebootEcArg::JumpRo => match ec.jump_ro() {
                 Ok(_) => {}
-                Err(err) => println!("Failed: {:?}", err),
+                Err(err) => eprintln!("Failed: {:?}", err),
             },
             RebootEcArg::JumpRw => match ec.jump_rw() {
                 Ok(_) => {}
-                Err(err) => println!("Failed: {:?}", err),
+                Err(err) => eprintln!("Failed: {:?}", err),
             },
             RebootEcArg::CancelJump => match ec.cancel_jump() {
                 Ok(_) => {}
-                Err(err) => println!("Failed: {:?}", err),
+                Err(err) => eprintln!("Failed: {:?}", err),
             },
             RebootEcArg::DisableJump => match ec.disable_jump() {
                 Ok(_) => {}
-                Err(err) => println!("Failed: {:?}", err),
+                Err(err) => eprintln!("Failed: {:?}", err),
             },
         }
     } else if let Some(delay) = &args.ec_hib_delay {
@@ -1137,7 +1137,7 @@ pub fn run_with_args(args: &Cli, _allupdate: bool) -> i32 {
         println!("Self-Test");
         let result = selftest(&ec);
         if result.is_none() {
-            println!("FAILED!!");
+            eprintln!("FAILED!!");
             return 1;
         }
     } else if args.power {
@@ -1227,7 +1227,7 @@ pub fn run_with_args(args: &Cli, _allupdate: bool) -> i32 {
             Ok(data) => Some(data),
             // TODO: Perhaps a more user-friendly error
             Err(e) => {
-                println!("Error {:?}", e);
+                eprintln!("Error {:?}", e);
                 None
             }
         };
@@ -1246,7 +1246,7 @@ pub fn run_with_args(args: &Cli, _allupdate: bool) -> i32 {
             Ok(data) => Some(data),
             // TODO: Perhaps a more user-friendly error
             Err(e) => {
-                println!("Error {:?}", e);
+                eprintln!("Error {:?}", e);
                 None
             }
         };
@@ -1265,7 +1265,7 @@ pub fn run_with_args(args: &Cli, _allupdate: bool) -> i32 {
             Ok(data) => Some(data),
             // TODO: Perhaps a more user-friendly error
             Err(e) => {
-                println!("Error {:?}", e);
+                eprintln!("Error {:?}", e);
                 None
             }
         };
@@ -1283,7 +1283,7 @@ pub fn run_with_args(args: &Cli, _allupdate: bool) -> i32 {
                     }
                 }
             } else {
-                println!("Capsule is invalid.");
+                eprintln!("Capsule is invalid.");
             }
         }
     } else if let Some(capsule_path) = &args.h2o_capsule {
@@ -1294,7 +1294,7 @@ pub fn run_with_args(args: &Cli, _allupdate: bool) -> i32 {
             Ok(data) => Some(data),
             // TODO: Perhaps a more user-friendly error
             Err(e) => {
-                println!("Error {:?}", e);
+                eprintln!("Error {:?}", e);
                 None
             }
         };
@@ -1347,7 +1347,7 @@ pub fn run_with_args(args: &Cli, _allupdate: bool) -> i32 {
             Ok(data) => Some(data),
             // TODO: Perhaps a more user-friendly error
             Err(e) => {
-                println!("Error {:?}", e);
+                eprintln!("Error {:?}", e);
                 None
             }
         };
@@ -1362,7 +1362,7 @@ pub fn run_with_args(args: &Cli, _allupdate: bool) -> i32 {
         match res {
             Ok(1) => println!("GPU Descriptor successfully written"),
             Ok(x) => println!("GPU Descriptor write failed with status code:  {}", x),
-            Err(err) => println!("GPU Descriptor write failed with error:  {:?}", err),
+            Err(err) => eprintln!("GPU Descriptor write failed with error:  {:?}", err),
         }
     } else if let Some(gpu_descriptor_file) = &args.flash_gpu_descriptor_file {
         if matches!(
@@ -1376,7 +1376,7 @@ pub fn run_with_args(args: &Cli, _allupdate: bool) -> i32 {
                 Ok(data) => Some(data),
                 // TODO: Perhaps a more user-friendly error
                 Err(e) => {
-                    println!("Error {:?}", e);
+                    eprintln!("Error {:?}", e);
                     None
                 }
             };
@@ -1387,11 +1387,11 @@ pub fn run_with_args(args: &Cli, _allupdate: bool) -> i32 {
                 let res = ec.set_gpu_descriptor(&data, args.dry_run);
                 match res {
                     Ok(()) => println!("GPU Descriptor successfully written"),
-                    Err(err) => println!("GPU Descriptor write failed with error:  {:?}", err),
+                    Err(err) => eprintln!("GPU Descriptor write failed with error:  {:?}", err),
                 }
             }
         } else {
-            println!("Unsupported on this platform");
+            eprintln!("Unsupported on this platform");
         }
     } else if let Some(dump_path) = &args.dump_gpu_descriptor_file {
         println!("Dumping to {}", dump_path);
@@ -1512,7 +1512,7 @@ fn selftest(ec: &CrosEc) -> Option<()> {
     if let Some(mem) = ec.dump_mem_region() {
         util::print_multiline_buffer(&mem, 0);
     } else {
-        println!("    Failed to read EC memory region");
+        eprintln!("    Failed to read EC memory region");
         return None;
     }
 
@@ -1537,7 +1537,7 @@ fn selftest(ec: &CrosEc) -> Option<()> {
     println!("  Getting AC info from EC");
     // All our laptops have at least 4 PD ports so far
     if power::get_pd_info(ec, 4).iter().any(|x| x.is_err()) {
-        println!("    Failed to get PD Info from EC");
+        eprintln!("    Failed to get PD Info from EC");
         return None;
     }
 
@@ -1546,7 +1546,7 @@ fn selftest(ec: &CrosEc) -> Option<()> {
         // TGL does not have this command, so we have to ignore it
         if err != EcError::Response(EcResponseStatus::InvalidCommand) {
             println!();
-            println!("Err: {:?}", err);
+            eprintln!("Err: {:?}", err);
         } else {
             println!(" - Skipped");
         }
@@ -1696,7 +1696,7 @@ fn analyze_ccgx_pd_fw(data: &[u8]) {
         println!("FW 2 (Main)");
         ccgx::binary::print_fw(&versions.main_fw);
     } else {
-        println!("Failed to read PD versions")
+        eprintln!("Failed to read PD versions")
     }
 }
 
@@ -1705,13 +1705,13 @@ pub fn analyze_ec_fw(data: &[u8]) {
     if let Some(ver) = ec_binary::read_ec_version(data, true) {
         ec_binary::print_ec_version(&ver, true);
     } else {
-        println!("Failed to read EC version")
+        eprintln!("Failed to read EC version")
     }
     // Readwrite firmware
     if let Some(ver) = ec_binary::read_ec_version(data, false) {
         ec_binary::print_ec_version(&ver, false);
     } else {
-        println!("Failed to read EC version")
+        eprintln!("Failed to read EC version")
     }
 }
 

--- a/framework_lib/src/commandline/uefi.rs
+++ b/framework_lib/src/commandline/uefi.rs
@@ -143,7 +143,7 @@ pub fn parse(args: &[String]) -> Cli {
                 if let (Ok(fan_idx), Ok(duty)) = (fan_idx, duty) {
                     Some((Some(fan_idx), duty))
                 } else {
-                    println!(
+                    eprintln!(
                         "Invalid values for --fansetduty: '{} {}'. Must be u32 integers.",
                         args[i + 1],
                         args[i + 2]
@@ -154,14 +154,14 @@ pub fn parse(args: &[String]) -> Cli {
                 if let Ok(duty) = args[i + 1].parse::<u32>() {
                     Some((None, duty))
                 } else {
-                    println!(
+                    eprintln!(
                         "Invalid values for --fansetduty: '{}'. Must be 0-100.",
                         args[i + 1],
                     );
                     None
                 }
             } else {
-                println!("--fansetduty requires one or two. [fan id] [duty] or [duty]");
+                eprintln!("--fansetduty requires one or two. [fan id] [duty] or [duty]");
                 None
             };
             found_an_option = true;
@@ -172,7 +172,7 @@ pub fn parse(args: &[String]) -> Cli {
                 if let (Ok(fan_idx), Ok(rpm)) = (fan_idx, rpm) {
                     Some((Some(fan_idx), rpm))
                 } else {
-                    println!(
+                    eprintln!(
                         "Invalid values for --fansetrpm: '{} {}'. Must be u32 integers.",
                         args[i + 1],
                         args[i + 2]
@@ -183,14 +183,14 @@ pub fn parse(args: &[String]) -> Cli {
                 if let Ok(rpm) = args[i + 1].parse::<u32>() {
                     Some((None, rpm))
                 } else {
-                    println!(
+                    eprintln!(
                         "Invalid values for --fansetrpm: '{}'. Must be an integer.",
                         args[i + 1],
                     );
                     None
                 }
             } else {
-                println!("--fansetrpm requires one or two. [fan id] [rpm] or [rpm]");
+                eprintln!("--fansetrpm requires one or two. [fan id] [rpm] or [rpm]");
                 None
             };
             found_an_option = true;
@@ -222,11 +222,11 @@ pub fn parse(args: &[String]) -> Cli {
                 } else if inputdeck_mode == "on" {
                     Some(InputDeckModeArg::On)
                 } else {
-                    println!("Invalid value for --inputdeck-mode: {}", inputdeck_mode);
+                    eprintln!("Invalid value for --inputdeck-mode: {}", inputdeck_mode);
                     None
                 }
             } else {
-                println!(
+                eprintln!(
                     "Need to provide a value for --inputdeck-mode. Either `auto`, `off`, or `on`"
                 );
                 None
@@ -240,7 +240,7 @@ pub fn parse(args: &[String]) -> Cli {
                 if let Ok(percent) = args[i + 1].parse::<u8>() {
                     Some(Some(percent))
                 } else {
-                    println!(
+                    eprintln!(
                         "Invalid value for --charge-limit: '{}'. Must be integer < 100.",
                         args[i + 1]
                     );
@@ -257,7 +257,7 @@ pub fn parse(args: &[String]) -> Cli {
                 if let (Ok(limit), Ok(soc)) = (limit, soc) {
                     Some((limit, Some(soc)))
                 } else {
-                    println!(
+                    eprintln!(
                         "Invalid values for --charge-current-limit: '{} {}'. Must be u32 integers.",
                         args[i + 1],
                         args[i + 2]
@@ -268,14 +268,14 @@ pub fn parse(args: &[String]) -> Cli {
                 if let Ok(limit) = args[i + 1].parse::<u32>() {
                     Some((limit, None))
                 } else {
-                    println!(
+                    eprintln!(
                         "Invalid values for --charge-current-limit: '{}'. Must be an integer.",
                         args[i + 1],
                     );
                     None
                 }
             } else {
-                println!("--charge-current-limit requires one or two. [limit] [soc] or [limit]");
+                eprintln!("--charge-current-limit requires one or two. [limit] [soc] or [limit]");
                 None
             };
             found_an_option = true;
@@ -286,7 +286,7 @@ pub fn parse(args: &[String]) -> Cli {
                 if let (Ok(limit), Ok(soc)) = (limit, soc) {
                     Some((limit, Some(soc)))
                 } else {
-                    println!(
+                    eprintln!(
                         "Invalid values for --charge-rate-limit: '{} {}'. Must be u32 integers.",
                         args[i + 1],
                         args[i + 2]
@@ -297,14 +297,14 @@ pub fn parse(args: &[String]) -> Cli {
                 if let Ok(limit) = args[i + 1].parse::<f32>() {
                     Some((limit, None))
                 } else {
-                    println!(
+                    eprintln!(
                         "Invalid values for --charge-rate-limit: '{}'. Must be an integer.",
                         args[i + 1],
                     );
                     None
                 }
             } else {
-                println!("--charge-rate-limit requires one or two. [limit] [soc] or [limit]");
+                eprintln!("--charge-rate-limit requires one or two. [limit] [soc] or [limit]");
                 None
             };
             found_an_option = true;
@@ -320,7 +320,7 @@ pub fn parse(args: &[String]) -> Cli {
                 if let Ok(percent) = args[i + 1].parse::<u8>() {
                     Some(Some(percent))
                 } else {
-                    println!(
+                    eprintln!(
                         "Invalid value for --kblight: '{}'. Must be integer < 100.",
                         args[i + 1]
                     );
@@ -339,7 +339,7 @@ pub fn parse(args: &[String]) -> Cli {
                 }
                 colors
             } else {
-                println!("--rgbkbd requires at least 2 arguments, the start key and an RGB value");
+                eprintln!("--rgbkbd requires at least 2 arguments, the start key and an RGB value");
                 vec![]
             }
         } else if arg == "--ps2-enable" {
@@ -350,7 +350,7 @@ pub fn parse(args: &[String]) -> Cli {
                 } else if enable_arg == "false" {
                     Some(false)
                 } else {
-                    println!(
+                    eprintln!(
                         "Need to provide a value for --ps2-enable: '{}'. {}",
                         args[i + 1],
                         "Must be `true` or `false`",
@@ -358,7 +358,7 @@ pub fn parse(args: &[String]) -> Cli {
                     None
                 }
             } else {
-                println!("Need to provide a value for --tablet-mode. One of: `auto`, `tablet` or `laptop`");
+                eprintln!("Need to provide a value for --tablet-mode. One of: `auto`, `tablet` or `laptop`");
                 None
             };
             found_an_option = true;
@@ -372,7 +372,7 @@ pub fn parse(args: &[String]) -> Cli {
                 } else if tablet_mode_arg == "laptop" {
                     Some(TabletModeArg::Laptop)
                 } else {
-                    println!(
+                    eprintln!(
                         "Need to provide a value for --tablet-mode: '{}'. {}",
                         args[i + 1],
                         "Must be one of: `auto`, `tablet` or `laptop`",
@@ -380,7 +380,7 @@ pub fn parse(args: &[String]) -> Cli {
                     None
                 }
             } else {
-                println!("Need to provide a value for --tablet-mode. One of: `auto`, `tablet` or `laptop`");
+                eprintln!("Need to provide a value for --tablet-mode. One of: `auto`, `tablet` or `laptop`");
                 None
             };
             found_an_option = true;
@@ -398,7 +398,7 @@ pub fn parse(args: &[String]) -> Cli {
                 } else if fp_led_level_arg == "auto" {
                     Some(Some(FpBrightnessArg::Auto))
                 } else {
-                    println!("Invalid value for --fp-led-level: {}", fp_led_level_arg);
+                    eprintln!("Invalid value for --fp-led-level: {}", fp_led_level_arg);
                     None
                 }
             } else {
@@ -409,7 +409,7 @@ pub fn parse(args: &[String]) -> Cli {
             cli.fp_brightness = if args.len() > i + 1 {
                 if let Ok(fp_brightness_arg) = args[i + 1].parse::<u8>() {
                     if fp_brightness_arg == 0 || fp_brightness_arg > 100 {
-                        println!(
+                        eprintln!(
                             "Invalid value for --fp-brightness: {}. Must be in the range of 1-100",
                             fp_brightness_arg
                         );
@@ -418,7 +418,7 @@ pub fn parse(args: &[String]) -> Cli {
                         Some(Some(fp_brightness_arg))
                     }
                 } else {
-                    println!("Invalid value for --fp-brightness. Must be in the range of 1-100");
+                    eprintln!("Invalid value for --fp-brightness. Must be in the range of 1-100");
                     None
                 }
             } else {
@@ -433,11 +433,11 @@ pub fn parse(args: &[String]) -> Cli {
                 } else if console_arg == "follow" {
                     Some(ConsoleArg::Follow)
                 } else {
-                    println!("Invalid value for --console: {}", console_arg);
+                    eprintln!("Invalid value for --console: {}", console_arg);
                     None
                 }
             } else {
-                println!("Need to provide a value for --console. Either `follow` or `recent`");
+                eprintln!("Need to provide a value for --console. Either `follow` or `recent`");
                 None
             };
             found_an_option = true;
@@ -455,11 +455,11 @@ pub fn parse(args: &[String]) -> Cli {
                 } else if reboot_ec_arg == "disable-jump" {
                     Some(RebootEcArg::DisableJump)
                 } else {
-                    println!("Invalid value for --reboot-ec: {}", reboot_ec_arg);
+                    eprintln!("Invalid value for --reboot-ec: {}", reboot_ec_arg);
                     None
                 }
             } else {
-                println!("Need to provide a value for --reboot-ec. Either `reboot`, `jump-ro`, `jump-rw`, `cancel-jump` or `disable-jump`");
+                eprintln!("Need to provide a value for --reboot-ec. Either `reboot`, `jump-ro`, `jump-rw`, `cancel-jump` or `disable-jump`");
                 None
             };
             found_an_option = true;
@@ -467,13 +467,13 @@ pub fn parse(args: &[String]) -> Cli {
             cli.ec_hib_delay = if args.len() > i + 1 {
                 if let Ok(delay) = args[i + 1].parse::<u32>() {
                     if delay == 0 {
-                        println!("Invalid value for --ec-hib-delay: {}. Must be >0", delay);
+                        eprintln!("Invalid value for --ec-hib-delay: {}. Must be >0", delay);
                         None
                     } else {
                         Some(Some(delay))
                     }
                 } else {
-                    println!("Invalid value for --fp-brightness. Must be amount in seconds >0");
+                    eprintln!("Invalid value for --fp-brightness. Must be amount in seconds >0");
                     None
                 }
             } else {
@@ -500,14 +500,14 @@ pub fn parse(args: &[String]) -> Cli {
                 if let Ok(pd) = args[i + 1].parse::<u8>() {
                     Some(pd)
                 } else {
-                    println!(
+                    eprintln!(
                         "Invalid value for --pd-reset: '{}'. Must be 0 or 1.",
                         args[i + 1],
                     );
                     None
                 }
             } else {
-                println!("--pd-reset requires specifying the PD controller");
+                eprintln!("--pd-reset requires specifying the PD controller");
                 None
             };
             found_an_option = true;
@@ -516,14 +516,14 @@ pub fn parse(args: &[String]) -> Cli {
                 if let Ok(pd) = args[i + 1].parse::<u8>() {
                     Some(pd)
                 } else {
-                    println!(
+                    eprintln!(
                         "Invalid value for --pd-disable: '{}'. Must be 0 or 1.",
                         args[i + 1],
                     );
                     None
                 }
             } else {
-                println!("--pd-disable requires specifying the PD controller");
+                eprintln!("--pd-disable requires specifying the PD controller");
                 None
             };
             found_an_option = true;
@@ -532,14 +532,14 @@ pub fn parse(args: &[String]) -> Cli {
                 if let Ok(pd) = args[i + 1].parse::<u8>() {
                     Some(pd)
                 } else {
-                    println!(
+                    eprintln!(
                         "Invalid value for --pd-enable: '{}'. Must be 0 or 1.",
                         args[i + 1],
                     );
                     None
                 }
             } else {
-                println!("--pd-enable requires specifying the PD controller");
+                eprintln!("--pd-enable requires specifying the PD controller");
                 None
             };
             found_an_option = true;
@@ -550,7 +550,7 @@ pub fn parse(args: &[String]) -> Cli {
             cli.pd_bin = if args.len() > i + 1 {
                 Some(args[i + 1].clone())
             } else {
-                println!("--pd-bin requires extra argument to denote input file");
+                eprintln!("--pd-bin requires extra argument to denote input file");
                 None
             };
             found_an_option = true;
@@ -558,7 +558,7 @@ pub fn parse(args: &[String]) -> Cli {
             cli.ec_bin = if args.len() > i + 1 {
                 Some(args[i + 1].clone())
             } else {
-                println!("--ec-bin requires extra argument to denote input file");
+                eprintln!("--ec-bin requires extra argument to denote input file");
                 None
             };
             found_an_option = true;
@@ -566,7 +566,7 @@ pub fn parse(args: &[String]) -> Cli {
             cli.capsule = if args.len() > i + 1 {
                 Some(args[i + 1].clone())
             } else {
-                println!("--capsule requires extra argument to denote input file");
+                eprintln!("--capsule requires extra argument to denote input file");
                 None
             };
             found_an_option = true;
@@ -574,7 +574,7 @@ pub fn parse(args: &[String]) -> Cli {
             cli.dump = if args.len() > i + 1 {
                 Some(args[i + 1].clone())
             } else {
-                println!("--dump requires extra argument to denote output file");
+                eprintln!("--dump requires extra argument to denote output file");
                 None
             };
             found_an_option = true;
@@ -582,7 +582,7 @@ pub fn parse(args: &[String]) -> Cli {
             cli.h2o_capsule = if args.len() > i + 1 {
                 Some(args[i + 1].clone())
             } else {
-                println!("--h2o-capsule requires extra argument to denote input file");
+                eprintln!("--h2o-capsule requires extra argument to denote input file");
                 None
             };
             found_an_option = true;
@@ -590,7 +590,7 @@ pub fn parse(args: &[String]) -> Cli {
             cli.dump_ec_flash = if args.len() > i + 1 {
                 Some(args[i + 1].clone())
             } else {
-                println!("--dump-ec-flash requires extra argument to denote output file");
+                eprintln!("--dump-ec-flash requires extra argument to denote output file");
                 None
             };
             found_an_option = true;
@@ -598,7 +598,7 @@ pub fn parse(args: &[String]) -> Cli {
             cli.flash_ec = if args.len() > i + 1 {
                 Some(args[i + 1].clone())
             } else {
-                println!("--flash-ec requires extra argument to denote input file");
+                eprintln!("--flash-ec requires extra argument to denote input file");
                 None
             };
             found_an_option = true;
@@ -606,7 +606,7 @@ pub fn parse(args: &[String]) -> Cli {
             cli.flash_ro_ec = if args.len() > i + 1 {
                 Some(args[i + 1].clone())
             } else {
-                println!("--flash-ro-ec requires extra argument to denote input file");
+                eprintln!("--flash-ro-ec requires extra argument to denote input file");
                 None
             };
             found_an_option = true;
@@ -614,7 +614,7 @@ pub fn parse(args: &[String]) -> Cli {
             cli.flash_rw_ec = if args.len() > i + 1 {
                 Some(args[i + 1].clone())
             } else {
-                println!("--flash-rw-ec requires extra argument to denote input file");
+                eprintln!("--flash-rw-ec requires extra argument to denote input file");
                 None
             };
             found_an_option = true;
@@ -622,7 +622,7 @@ pub fn parse(args: &[String]) -> Cli {
             cli.hash = if args.len() > i + 1 {
                 Some(args[i + 1].clone())
             } else {
-                println!("--hash requires extra argument to denote input file");
+                eprintln!("--hash requires extra argument to denote input file");
                 None
             };
             found_an_option = true;
@@ -634,7 +634,7 @@ pub fn parse(args: &[String]) -> Cli {
                 if left.is_ok() && right.is_ok() && back.is_ok() {
                     Some((left.unwrap(), right.unwrap(), back.unwrap()))
                 } else {
-                    println!(
+                    eprintln!(
                         "Invalid values for --pd-addrs: '{} {} {}'. Must be u16 integers.",
                         args[i + 1],
                         args[i + 2],
@@ -643,7 +643,7 @@ pub fn parse(args: &[String]) -> Cli {
                     None
                 }
             } else {
-                println!("--pd-addrs requires three arguments, one for each address");
+                eprintln!("--pd-addrs requires three arguments, one for each address");
                 None
             };
             found_an_option = true;
@@ -655,7 +655,7 @@ pub fn parse(args: &[String]) -> Cli {
                 if left.is_ok() && right.is_ok() && back.is_ok() {
                     Some((left.unwrap(), right.unwrap(), back.unwrap()))
                 } else {
-                    println!(
+                    eprintln!(
                         "Invalid values for --pd-ports: '{} {} {}'. Must be u16 integers.",
                         args[i + 1],
                         args[i + 2],
@@ -664,7 +664,7 @@ pub fn parse(args: &[String]) -> Cli {
                     None
                 }
             } else {
-                println!("--pd-ports requires two arguments, one for each port");
+                eprintln!("--pd-ports requires two arguments, one for each port");
                 None
             };
             found_an_option = true;
@@ -674,7 +674,7 @@ pub fn parse(args: &[String]) -> Cli {
             cli.compare_version = if args.len() > i + 1 {
                 Some(args[i + 1].clone())
             } else {
-                println!("--compare-version requires extra argument to denote version");
+                eprintln!("--compare-version requires extra argument to denote version");
                 None
             };
             found_an_option = true;
@@ -698,11 +698,11 @@ pub fn parse(args: &[String]) -> Cli {
                 } else if console_arg == "ac-right" {
                     Some(HardwareDeviceType::AcRight)
                 } else {
-                    println!("Invalid value for --device: {}", console_arg);
+                    eprintln!("Invalid value for --device: {}", console_arg);
                     None
                 }
             } else {
-                println!("Need to provide a value for --console. Possible values: bios, ec, pd0, pd1, rtm01, rtm23, ac-left, ac-right");
+                eprintln!("Need to provide a value for --console. Possible values: bios, ec, pd0, pd1, rtm01, rtm23, ac-left, ac-right");
                 None
             };
         } else if arg == "--flash-gpu-descriptor" {
@@ -726,7 +726,7 @@ pub fn parse(args: &[String]) -> Cli {
                 } else if magic.to_uppercase() == "SSD" {
                     Some((SetGpuSerialMagic::WriteSSDConfig as u8, sn))
                 } else {
-                    println!(
+                    eprintln!(
                         "Invalid values for --flash_gpu_descriptor: '{} {}'. Must be u8, 18 character string.",
                         args[i + 1],
                         args[i + 2]
@@ -734,7 +734,7 @@ pub fn parse(args: &[String]) -> Cli {
                     None
                 }
             } else {
-                println!("Need to provide a value for --flash_gpu_descriptor. TYPE_MAGIC SERIAL");
+                eprintln!("Need to provide a value for --flash_gpu_descriptor. TYPE_MAGIC SERIAL");
                 None
             };
             found_an_option = true;
@@ -742,7 +742,7 @@ pub fn parse(args: &[String]) -> Cli {
             cli.flash_gpu_descriptor_file = if args.len() > i + 1 {
                 Some(args[i + 1].clone())
             } else {
-                println!("Need to provide a value for --flash_gpu_descriptor_file. PATH");
+                eprintln!("Need to provide a value for --flash_gpu_descriptor_file. PATH");
                 None
             };
             found_an_option = true;
@@ -750,7 +750,7 @@ pub fn parse(args: &[String]) -> Cli {
             cli.dump_gpu_descriptor_file = if args.len() > i + 1 {
                 Some(args[i + 1].clone())
             } else {
-                println!("Need to provide a value for --dump_gpu_descriptor_file. PATH");
+                eprintln!("Need to provide a value for --dump_gpu_descriptor_file. PATH");
                 None
             };
             found_an_option = true;
@@ -760,7 +760,7 @@ pub fn parse(args: &[String]) -> Cli {
     let custom_platform = cli.pd_addrs.is_some() && cli.pd_ports.is_some();
     let no_customization = cli.pd_addrs.is_none() && cli.pd_ports.is_none();
     if !(custom_platform || no_customization) {
-        println!("To customize the platform you need to provide all of --pd-addrs, and --pd-ports");
+        eprintln!("To customize the platform you need to provide all of --pd-addrs, and --pd-ports");
     }
 
     if args.len() == 1 && cli.paginate {
@@ -769,7 +769,7 @@ pub fn parse(args: &[String]) -> Cli {
     }
 
     if !found_an_option {
-        println!(
+        eprintln!(
             "Failed to parse any commandline options. Commandline was: {:?}",
             args
         );

--- a/framework_lib/src/smbios.rs
+++ b/framework_lib/src/smbios.rs
@@ -206,11 +206,11 @@ pub fn get_smbios() -> Option<SMBiosData> {
     match smbioslib::table_load_from_device() {
         Ok(data) => Some(data),
         Err(ref e) if e.kind() == ErrorKind::PermissionDenied => {
-            println!("Must be root to get SMBIOS data.");
+            eprintln!("Must be root to get SMBIOS data.");
             None
         }
         Err(err) => {
-            println!("Failed to get SMBIOS: {:?}", err);
+            eprintln!("Failed to get SMBIOS: {:?}", err);
             None
         }
     }
@@ -225,7 +225,7 @@ pub fn get_product_name() -> Option<String> {
 
     let smbios = get_smbios();
     if smbios.is_none() {
-        println!("Failed to find SMBIOS");
+        eprintln!("Failed to find SMBIOS");
         return None;
     }
     let mut smbios = smbios.into_iter().flatten();
@@ -317,7 +317,7 @@ pub fn get_platform() -> Option<Platform> {
     if let Some(platform) = platform {
         Config::set(platform);
     } else {
-        println!("Failed to find PlatformFamily");
+        eprintln!("Failed to find PlatformFamily");
     }
 
     assert!(cached_platform.is_none());

--- a/framework_lib/src/uefi/fs.rs
+++ b/framework_lib/src/uefi/fs.rs
@@ -21,7 +21,7 @@ pub fn shell_read_file(path: &str) -> Option<Vec<u8>> {
     let shell = if let Some(shell) = find_shell_handle() {
         shell
     } else {
-        println!("Failed to open Shell Protocol");
+        eprintln!("Failed to open Shell Protocol");
         return None;
     };
 
@@ -34,14 +34,14 @@ pub fn shell_read_file(path: &str) -> Option<Vec<u8>> {
     let handle = if let Ok(handle) = handle {
         handle
     } else {
-        println!("Failed to open file: {:?}", handle);
+        eprintln!("Failed to open file: {:?}", handle);
         return None;
     };
 
     let handle = if let Some(handle) = handle {
         handle
     } else {
-        println!("Failed to open file: {:?}", handle);
+        eprintln!("Failed to open file: {:?}", handle);
         return None;
     };
     let file_handle = handle;
@@ -63,7 +63,7 @@ pub fn shell_write_file(path: &str, data: &[u8]) -> Result {
     let shell = if let Some(shell) = find_shell_handle() {
         shell
     } else {
-        println!("Failed to open Shell Protocol");
+        eprintln!("Failed to open Shell Protocol");
         return Status::LOAD_ERROR.into();
     };
 
@@ -76,13 +76,13 @@ pub fn shell_write_file(path: &str, data: &[u8]) -> Result {
     let handle = if let Ok(handle) = handle {
         handle
     } else {
-        println!("Failed to open file: {:?}", handle);
+        eprintln!("Failed to open file: {:?}", handle);
         return Status::LOAD_ERROR.into();
     };
     let handle = if let Some(handle) = handle {
         handle
     } else {
-        println!("Failed to open file: {:?}", handle);
+        eprintln!("Failed to open file: {:?}", handle);
         return Status::LOAD_ERROR.into();
     };
     let file_handle = handle;
@@ -90,7 +90,7 @@ pub fn shell_write_file(path: &str, data: &[u8]) -> Result {
     //// TODO: Free file_info buffer
     //let file_info = (shell.0.GetFileInfo)(file_handle);
     //if file_info.is_null() {
-    //    println!("Failed to get file info");
+    //    eprintln!("Failed to get file info");
     //    return ret;
     //}
 
@@ -104,7 +104,7 @@ pub fn shell_write_file(path: &str, data: &[u8]) -> Result {
     ////    file_info.Size = 0;
     ////    let ret = (shell.0.SetFileInfo)(file_handle, file_info);
     ////    if ret.0 != 0 {
-    ////        println!("Failed to set file info");
+    ////        eprintln!("Failed to set file info");
     ////        return ret;
     ////    }
     ////}
@@ -112,11 +112,11 @@ pub fn shell_write_file(path: &str, data: &[u8]) -> Result {
     //let mut buffer_size = data.len() as usize;
     //let ret = (shell.0.WriteFile)(file_handle, &mut buffer_size, data.as_ptr());
     //if ret.0 != 0 {
-    //    println!("Failed to write file");
+    //    eprintln!("Failed to write file");
     //    return ret;
     //}
     //if buffer_size != data.len() {
-    //    println!(
+    //    eprintln!(
     //        "Failed to write whole buffer. Instead of {} wrote {} bytes.",
     //        data.len(),
     //        buffer_size


### PR DESCRIPTION
[Context.](https://github.com/iffse/pay-respects/issues/76)

`framework_tool` uses both `stdout` and `stderr`. But the former one is being overused, having most of the error messages which should be sent to `stderr`.

This PR only changed print statements which should go to `stderr`.