### PR TITLE
rgbkbd: Name arguments

### DIFF
--- a/framework_lib/src/commandline/clap_std.rs
+++ b/framework_lib/src/commandline/clap_std.rs
@@ -202,7 +202,7 @@ struct ClapCli {
     /// <key> <RGB> [<RGB> ...]
     /// Example: 0 0xFF000 0x00FF00 0x0000FF
     #[clap(num_args = 2..)]
-    #[arg(long, value_parser=maybe_hex::<u64>)]
+    #[arg(long, value_parser=maybe_hex::<u64>, value_names(["START", "HEXCOLOR"]))]
     rgbkbd: Vec<u64>,
 
     /// Control PS2 touchpad emulation (DEBUG COMMAND, if touchpad not working, reboot system)


### PR DESCRIPTION
Now when running `framework_tool --rgbkbd` instead of

```
error: 2 values required by '--rgbkbd <RGBKBD> <RGBKBD>...'; only 1 was provided
```

it says:

```
error: 2 values required by '--rgbkbd <START> <HEXCOLOR>...'; only 1 was provided
```

Fixes #189