### PR TITLE
GpuVendor: Add Nvidia GN22 ID

### DIFF
--- a/framework_lib/src/chromium_ec/commands.rs
+++ b/framework_lib/src/chromium_ec/commands.rs
@@ -1426,6 +1426,7 @@ pub enum GpuVendor {
     GpuAmdR23M = 0x02,
     SsdHolder = 0x03,
     PcieAccessory = 0x4,
+    NvidiaGn22 = 0x5,
 }
 
 #[repr(C, packed)]


### PR DESCRIPTION
```
> sudo framework_tool --expansion-bay
Expansion Bay
  Enabled:       true
  No fault:      true
  Door closed:   true
  Board:         DualInterposer
  Serial Number: FRAKJECP8250000000
  Config:        Pcie8x1
  Vendor:        NvidiaGn22
  Expansion Bay EEPROM
    Valid:       true
    HW Version:  4.0
```