### PR TITLE
esrt: Get full ESRT table entries on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,7 +365,7 @@ dependencies = [
  "rustc_version",
  "toml 0.8.22",
  "vswhom",
- "winreg",
+ "winreg 0.52.0",
 ]
 
 [[package]]
@@ -436,6 +436,7 @@ dependencies = [
  "uefi-services",
  "windows 0.59.0",
  "windows-version",
+ "winreg 0.55.0",
  "wmi",
 ]
 
@@ -1604,6 +1605,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1814,6 +1824,16 @@ checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "winreg"
+version = "0.55.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/framework_lib/Cargo.toml
+++ b/framework_lib/Cargo.toml
@@ -51,6 +51,7 @@ clap = { version = "4.5", features = ["derive", "cargo"] }
 clap-num = { version = "1.2.0" }
 clap-verbosity-flag = { version = "2.2.1" }
 windows-version = "0.1.4"
+winreg = "0.55.0"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.155"


### PR DESCRIPTION
On UEFI Shell, Linux and FreeBSD we have been able to decode everything already. Only on Windows, wasn't getting all the data.

Before:

```
> framework_tool.exe --esrt
ESRT Table
  ResourceCount:        1
  ResourceCountMax:     1
  ResourceVersion:      1
ESRT Entry 0
  GUID:                 9C13B7F1-D618-5D68-BE61-6B17881014A7
  GUID:                 Amd13Ai300Bios
  Type:                 SystemFirmware
  Version:              0x304 (772)
  Min FW Version:       0x0 (0)
  Capsule Flags:        0x0
  Last Attempt Version: 0x0 (0)
  Last Attempt Status:  Success
```

After

```
> framework_tool.exe --esrt
ESRT Table
  ResourceCount:        1
  ResourceCountMax:     1
  ResourceVersion:      1
ESRT Entry 0
  GUID:                 9C13B7F1-D618-5D68-BE61-6B17881014A7
  GUID:                 Amd13Ai300Bios
  Type:                 SystemFirmware
  Version:              0x304 (772)
  Min FW Version:       0x204 (516)
  Capsule Flags:        0x0
  Last Attempt Version: 0x304 (772)
  Last Attempt Status:  Success
```