### PR TITLE
clap_std: Remove unused import

### DIFF
--- a/framework_lib/src/commandline/clap_std.rs
+++ b/framework_lib/src/commandline/clap_std.rs
@@ -3,7 +3,7 @@
 //! as well as on the UEFI shell tool.
 use clap::error::ErrorKind;
 use clap::Parser;
-use clap::{arg, command, Arg, Args, FromArgMatches};
+use clap::{command, Arg, Args, FromArgMatches};
 use clap_num::maybe_hex;
 
 use crate::chromium_ec::commands::SetGpuSerialMagic;


### PR DESCRIPTION
error: unused import: `arg`
 --> framework_lib/src/commandline/clap_std.rs:6:12
  |
6 | use clap::{arg, command, Arg, Args, FromArgMatches};
  |            ^^^
  |
  = note: `-D unused-imports` implied by `-D warnings`
  = help: to override `-D warnings` add `#[allow(unused_imports)]`