### PR TITLE
framework_lib: Restrict portio modules to x86/x86_64 architectures

### DIFF
--- a/framework_lib/src/chromium_ec/mod.rs
+++ b/framework_lib/src/chromium_ec/mod.rs
@@ -27,11 +27,11 @@ pub mod commands;
 mod cros_ec;
 pub mod i2c_passthrough;
 pub mod input_deck;
-#[cfg(not(windows))]
+#[cfg(all(not(windows), any(target_arch = "x86", target_arch = "x86_64")))]
 mod portio;
-#[cfg(not(windows))]
+#[cfg(all(not(windows), any(target_arch = "x86", target_arch = "x86_64")))]
 mod portio_hwio;
-#[cfg(not(windows))]
+#[cfg(all(not(windows), any(target_arch = "x86", target_arch = "x86_64")))]
 mod portio_mec;
 #[allow(dead_code)]
 mod protocol;
@@ -241,7 +241,7 @@ fn available_drivers() -> Vec<CrosEcDriverType> {
         drivers.push(CrosEcDriverType::CrosEc);
     }
 
-    #[cfg(not(windows))]
+    #[cfg(all(not(windows), any(target_arch = "x86", target_arch = "x86_64")))]
     drivers.push(CrosEcDriverType::Portio);
 
     drivers
@@ -1861,7 +1861,7 @@ impl CrosEcDriver for CrosEc {
 
         // TODO: Change this function to return EcResult instead and print the error only in UI code
         print_err(match self.driver {
-            #[cfg(not(windows))]
+            #[cfg(all(not(windows), any(target_arch = "x86", target_arch = "x86_64")))]
             CrosEcDriverType::Portio => portio::read_memory(offset, length),
             #[cfg(windows)]
             CrosEcDriverType::Windows => windows::read_memory(offset, length),
@@ -1883,7 +1883,7 @@ impl CrosEcDriver for CrosEc {
         }
 
         match self.driver {
-            #[cfg(not(windows))]
+            #[cfg(all(not(windows), any(target_arch = "x86", target_arch = "x86_64")))]
             CrosEcDriverType::Portio => portio::send_command(command, command_version, data),
             #[cfg(windows)]
             CrosEcDriverType::Windows => windows::send_command(command, command_version, data),


### PR DESCRIPTION
Currently, I'm working on the `framework-lib` package in Debia,n and it fails to build on all non-x86 architectures: https://buildd.debian.org/status/package.php?p=rust-framework-lib

The error messages look the following way:

```
error[E0432]: unresolved import `libc::ioperm`
 --> src/chromium_ec/portio.rs:9:5
  |
9 | use libc::ioperm;
  |     ^^^^^^^^^^^^ no `ioperm` in the root

error[E0432]: unresolved import `libc::ioperm`
 --> src/chromium_ec/portio_mec.rs:9:5
  |
9 | use libc::ioperm;
  |     ^^^^^^^^^^^^ no `ioperm` in the root
```

After some investigation, I've noticed that this happens because `libc::ioperm` is only available on Linux x86/x86_64. The cfg attributes were only checking for `target_os = "linux"`, causing build failures on arm, arm64, ppc64el, riscv64, s390x, loong64, and other non-x86 architectures. Non-x86 Linux already uses the /dev/port file fallback in `portio_hwio.rs`, so ioperm is not needed there

The fix adds the corresponding cfg attributes