### PR TITLE
snap: Turn into strict snap

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -68,3 +68,37 @@ jobs:
       with:
         name: framework-tool-rpm
         path: target/generate-rpm/*.rpm
+
+  build-snap:
+    name: Build Snap
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Build snap
+      uses: snapcore/action-build@v1
+      id: build
+
+    - name: Upload snap artifact
+      uses: actions/upload-artifact@v6
+      with:
+        name: framework-tool-snap
+        path: ${{ steps.build.outputs.snap }}
+
+    - name: Publish to edge channel
+      if: github.ref == 'refs/heads/main'
+      uses: snapcore/action-publish@v1
+      env:
+        SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+      with:
+        snap: ${{ steps.build.outputs.snap }}
+        release: edge
+
+    - name: Publish to candidate channel
+      if: github.ref_type == 'tag' || github.event_name == 'release'
+      uses: snapcore/action-publish@v1
+      env:
+        SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+      with:
+        snap: ${{ steps.build.outputs.snap }}
+        release: candidate

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ dump.bmp
 OVMF.fd
 OVMF_CODE.fd
 OVMF_VARS.fd
+
+# Snap
+*.snap

--- a/README.md
+++ b/README.md
@@ -32,8 +32,45 @@ You can find lots of examples in [EXAMPLES.md](./EXAMPLES.md).
   - Build from source
 - Homebrew
   - Add [this homebrew tap](https://github.com/ublue-os/homebrew-tap), then `brew install --cask framework-tool`
+- Snap (Not yet in the snap store!)
+  - `sudo snap install framework-tool`
+  - Then connect the required interfaces (see [Snap Interfaces](#snap-interfaces) below)
 - Cargo (Any distro)
   - `cargo install --locked framework_tool`
+
+#### Snap Interfaces
+
+The snap uses strict confinement. After installing, connect the required interfaces
+to allow access to the hardware:
+
+```sh
+# Required for most functionality (EC communication)
+sudo snap connect framework-tool:cros-ec
+sudo snap connect framework-tool:hardware-observe
+
+# Required for HID devices (touchpad, touchscreen, PD controller firmware)
+sudo snap connect framework-tool:hidraw
+
+# Required for USB devices (expansion cards, input modules, camera)
+sudo snap connect framework-tool:raw-usb
+
+# Required for NVMe firmware version detection
+sudo snap connect framework-tool:block-devices
+
+# Required for EC port I/O fallback (when cros_ec driver is unavailable)
+sudo snap connect framework-tool:io-ports-control
+
+# Required for SMBIOS table fallback via /dev/mem
+sudo snap connect framework-tool:physical-memory-observe
+```
+
+You can connect all interfaces at once:
+
+```sh
+for plug in cros-ec hardware-observe hidraw raw-usb block-devices io-ports-control physical-memory-observe; do
+  sudo snap connect framework-tool:$plug
+done
+```
 
 ### Windows
 

--- a/README.md
+++ b/README.md
@@ -40,8 +40,16 @@ You can find lots of examples in [EXAMPLES.md](./EXAMPLES.md).
 
 #### Snap Interfaces
 
-The snap uses strict confinement. After installing, connect the required interfaces
-to allow access to the hardware:
+The snap uses strict confinement. Several interfaces (`cros-ec`, `hidraw`) require
+store assertions or a gadget snap to provide slots, which are not available on
+standard desktop systems. For local testing, install with `--devmode`:
+
+```sh
+sudo snap install --dangerous --devmode framework-tool_*.snap
+```
+
+When installed from the snap store (with proper assertions), connect the required
+interfaces to allow access to the hardware:
 
 ```sh
 # Required for most functionality (EC communication)

--- a/contrib/snap.md
+++ b/contrib/snap.md
@@ -24,22 +24,19 @@ snapcraft clean
 
 ## Installing Locally
 
-Install the locally built snap (bypasses store signature check):
+Several interfaces (`cros-ec`, `hidraw`) require store assertions or a gadget
+snap to provide slots, which are not available on standard desktop systems.
+For local testing, install with `--devmode` to bypass confinement:
 
 ```sh
-sudo snap install --dangerous framework-tool_*.snap
+sudo snap install --dangerous --devmode framework-tool_*.snap
 ```
 
 ## Connecting Interfaces
 
-The snap uses strict confinement, so hardware interfaces must be connected
-manually after install:
-
-```sh
-for plug in cros-ec hardware-observe hidraw raw-usb block-devices io-ports-control physical-memory-observe; do
-  sudo snap connect framework-tool:$plug
-done
-```
+See the [Snap Interfaces](../../README.md#snap-interfaces) section in the README
+for the full list of interface connect commands (applicable when installed from
+the snap store with proper assertions).
 
 Verify the connections:
 

--- a/contrib/snap.md
+++ b/contrib/snap.md
@@ -1,0 +1,82 @@
+# Snap Package
+
+## Building
+
+Make sure `snapcraft` is installed:
+
+```sh
+sudo snap install snapcraft --classic
+```
+
+Build the snap:
+
+```sh
+snapcraft
+```
+
+This produces a file like `framework-tool_v0.6.1-20-gabda498ca6_amd64.snap`.
+
+To clean up build artifacts and start fresh:
+
+```sh
+snapcraft clean
+```
+
+## Installing Locally
+
+Install the locally built snap (bypasses store signature check):
+
+```sh
+sudo snap install --dangerous framework-tool_*.snap
+```
+
+## Connecting Interfaces
+
+The snap uses strict confinement, so hardware interfaces must be connected
+manually after install:
+
+```sh
+for plug in cros-ec hardware-observe hidraw raw-usb block-devices io-ports-control physical-memory-observe; do
+  sudo snap connect framework-tool:$plug
+done
+```
+
+Verify the connections:
+
+```sh
+snap connections framework-tool
+```
+
+## Testing
+
+```sh
+# Basic functionality
+sudo framework-tool --help
+sudo framework-tool --versions
+sudo framework-tool --esrt
+
+# EC communication (needs cros-ec + hardware-observe)
+sudo framework-tool --power
+sudo framework-tool --pdports
+
+# HID devices (needs hidraw)
+sudo framework-tool --touchpad-info
+
+# USB devices (needs raw-usb)
+sudo framework-tool --dp-hdmi-info
+sudo framework-tool --audio-card-info
+
+# NVMe (needs block-devices)
+sudo framework-tool --nvme-info
+```
+
+If a command fails with a permission error, check which interface it needs
+and make sure it is connected.
+
+## Publishing
+
+See: https://snapcraft.io/docs/releasing-your-app
+
+Note: Several interfaces (`block-devices`, `physical-memory-observe`,
+`io-ports-control`, `system-files`) are privileged and require a manual
+review by the snap store team before they can be used in a published snap.

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,12 @@
 name: framework-tool
+title: Framework Tool
 base: core24
 adopt-info: framework-tool
+license: BSD-2-Clause
+contact: https://github.com/FrameworkComputer/framework-system/issues
+issues: https://github.com/FrameworkComputer/framework-system/issues
+source-code: https://github.com/FrameworkComputer/framework-system
+website: https://frame.work
 summary: CLI tool to inspect and control Framework Computer systems
 description: |
   framework_tool is a CLI utility to interact with Framework Computer laptop
@@ -16,8 +22,17 @@ description: |
   Note: Most features require root privileges (sudo framework-tool ...).
 
 grade: stable
-confinement: classic
+confinement: strict
 compression: lzo
+
+# /dev/cros_ec needs ioctl access, which requires custom-device interface.
+# This needs a store assertion for the slot. For local testing use --devmode.
+plugs:
+  cros-ec:
+    interface: custom-device
+    custom-device: cros-ec
+    devices:
+      - /dev/cros_ec
 
 parts:
   framework-tool:
@@ -35,14 +50,14 @@ parts:
     override-pull: |
       craftctl default
       VERSION=$(craftctl get version)
-      if [ -z $VERSION ]; then
+      if [ -z "$VERSION" ] && git rev-parse --git-dir > /dev/null 2>&1; then
         VERSION=$(git describe --tags --abbrev=10)
-        craftctl set version=$VERSION
+        craftctl set version="$VERSION"
       fi
     override-build: |
       cd "${CRAFT_PART_SRC}"
       cargo build --release -p framework_tool --features nvidia
-      install -Dm755 target/release/framework_tool "${CRAFT_PART_INSTALL}/bin/framework_tool"
+      install -Dm755 "${CRAFT_PART_SRC}/target/release/framework_tool" "${CRAFT_PART_INSTALL}/bin/framework_tool"
       install -Dm644 "${CRAFT_PART_SRC}/completions/bash/framework_tool" \
         "${CRAFT_PART_INSTALL}/share/bash-completion/completions/framework_tool"
       install -Dm644 "${CRAFT_PART_SRC}/completions/zsh/_framework_tool" \
@@ -53,3 +68,17 @@ parts:
 apps:
   framework-tool:
     command: bin/framework_tool
+    plugs:
+      # EC communication via /dev/cros_ec ioctl
+      - cros-ec
+      # HID devices: touchpad, touchscreen, PD controller firmware
+      - hidraw
+      # USB devices: audio card, camera, USB hub, input modules
+      - raw-usb
+      # NVMe device access for firmware version detection
+      - block-devices
+      # /dev/mem for SMBIOS table fallback, /dev/port for EC port I/O
+      - physical-memory-observe
+      - io-ports-control
+      # /sys/firmware (SMBIOS/DMI, EFI ESRT), /sys/class/mei, hardware enumeration
+      - hardware-observe

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,55 @@
+name: framework-tool
+base: core24
+adopt-info: framework-tool
+summary: CLI tool to inspect and control Framework Computer systems
+description: |
+  framework_tool is a CLI utility to interact with Framework Computer laptop
+  and desktop firmware and hardware. Features include:
+  .
+  - Firmware inspection and updates (BIOS, EC, PD controllers, retimers)
+  - System status monitoring (power, thermal, sensors, USB-C ports)
+  - Hardware configuration (keyboard backlight, battery charge limits, fan control)
+  - Expansion card management (HDMI/DP/audio cards)
+  - Framework 16 specific features (input deck, expansion bay)
+  - NVIDIA GPU support
+  .
+  Note: Most features require root privileges (sudo framework-tool ...).
+
+grade: stable
+confinement: classic
+compression: lzo
+
+parts:
+  framework-tool:
+    plugin: rust
+    source: .
+    build-packages:
+      - libhidapi-dev
+      - libusb-1.0-0-dev
+      - libudev-dev
+      - pkg-config
+    stage-packages:
+      - libhidapi-hidraw0
+      - libusb-1.0-0
+      - libudev1
+    override-pull: |
+      craftctl default
+      VERSION=$(craftctl get version)
+      if [ -z $VERSION ]; then
+        VERSION=$(git describe --tags --abbrev=10)
+        craftctl set version=$VERSION
+      fi
+    override-build: |
+      cd "${CRAFT_PART_SRC}"
+      cargo build --release -p framework_tool --features nvidia
+      install -Dm755 target/release/framework_tool "${CRAFT_PART_INSTALL}/bin/framework_tool"
+      install -Dm644 "${CRAFT_PART_SRC}/completions/bash/framework_tool" \
+        "${CRAFT_PART_INSTALL}/share/bash-completion/completions/framework_tool"
+      install -Dm644 "${CRAFT_PART_SRC}/completions/zsh/_framework_tool" \
+        "${CRAFT_PART_INSTALL}/share/zsh/site-functions/_framework_tool"
+      install -Dm644 "${CRAFT_PART_SRC}/completions/fish/framework_tool.fish" \
+        "${CRAFT_PART_INSTALL}/share/fish/vendor_completions.d/framework_tool.fish"
+
+apps:
+  framework-tool:
+    command: bin/framework_tool

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -25,8 +25,9 @@ grade: stable
 confinement: strict
 compression: lzo
 
-# /dev/cros_ec needs ioctl access, which requires custom-device interface.
-# This needs a store assertion for the slot. For local testing use --devmode.
+# custom-device needs a store assertion for the slot.
+# hidraw slots must be provided by the core or gadget snap.
+# For local testing use --devmode to bypass these restrictions.
 plugs:
   cros-ec:
     interface: custom-device


### PR DESCRIPTION
On top of #294 

cannot properly test because:

```
# This needs a store assertion for the slot. For local testing use --devmode.
plugs:
  cros-ec:
    interface: custom-device
    custom-device: cros-ec
    devices:
      - /dev/cros_ec
 ```