### PR TITLE
Fix typo in EXAMPLES.md for brightness percentage

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -639,7 +639,7 @@ Fingerprint LED Brightness
   Requested:  Auto
   Brightness: 55%
 
-# Set it to a custom perfentage
+# Set it to a custom percentage
 > framework_tool --fp-brightness 42
 Fingerprint LED Brightness
   Requested:  Custom


### PR DESCRIPTION
Just a simple fix for a typo I noticed while reading the docs.