### PR TITLE
chore: Bump version to 0.6.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -380,7 +380,7 @@ dependencies = [
 
 [[package]]
 name = "framework_lib"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "built",
  "clap",
@@ -416,7 +416,7 @@ dependencies = [
 
 [[package]]
 name = "framework_tool"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "embed-resource",
  "framework_lib",
@@ -427,7 +427,7 @@ dependencies = [
 
 [[package]]
 name = "framework_uefi"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "framework_lib",
  "log",

--- a/flake.nix
+++ b/flake.nix
@@ -91,7 +91,7 @@
           in
           rustPlatform.buildRustPackage {
             pname = "framework_tool";
-            version = "0.6.2";
+            version = "0.6.3";
 
             src = buildSrc;
 
@@ -144,7 +144,7 @@
           in
           rustPlatformWindows.buildRustPackage {
             pname = "framework_tool";
-            version = "0.6.2";
+            version = "0.6.3";
 
             src = buildSrc;
 
@@ -194,7 +194,7 @@
           in
           rustPlatform.buildRustPackage {
             pname = "framework_uefi";
-            version = "0.6.2";
+            version = "0.6.3";
 
             src = buildSrc;
 

--- a/framework_lib/Cargo.toml
+++ b/framework_lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "framework_lib"
-version = "0.6.2"
+version = "0.6.3"
 description = "Library to control Framework Computer systems"
 homepage = "https://github.com/FrameworkComputer/framework-system"
 repository = "https://github.com/FrameworkComputer/framework-system"

--- a/framework_tool/Cargo.toml
+++ b/framework_tool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "framework_tool"
-version = "0.6.2"
+version = "0.6.3"
 description = "Tool to control Framework Computer systems"
 homepage = "https://github.com/FrameworkComputer/framework-system"
 repository = "https://github.com/FrameworkComputer/framework-system"
@@ -19,7 +19,7 @@ nvidia = [ "framework_lib/nvidia" ]
 
 [dependencies.framework_lib]
 path = "../framework_lib"
-version = "0.6.2"
+version = "0.6.3"
 
 [build-dependencies]
 static_vcruntime = "3.0"

--- a/framework_uefi/Cargo.toml
+++ b/framework_uefi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "framework_uefi"
-version = "0.6.2"
+version = "0.6.3"
 description = "UEFI Tool to control Framework Computer systems"
 homepage = "https://github.com/FrameworkComputer/framework-system"
 repository = "https://github.com/FrameworkComputer/framework-system"
@@ -24,6 +24,6 @@ log = { version = "0.4", default-features = true }
 
 [dependencies.framework_lib]
 path = "../framework_lib"
-version = "0.6.2"
+version = "0.6.3"
 features = ["uefi"]
 default-features = false


### PR DESCRIPTION
- [x] Make sure to update all versions in Cargo.toml and Cargo.lock files
- [x] Tag
- [x] Download binaries from github action run on tag
- [x] Sign windows exe with EV cert
- [x] Create release on GitHub with release notes and upload binaries
- [x] Notify distribution maintainers (See README)
- [ ] Do winget release (See below)
- [x] Do crates.io release (See below)
- [ ] Do freebsd release (See below)