### PR TITLE
fw16: fix invalid GPU read lengths

### DIFF
--- a/framework_lib/src/chromium_ec/i2c_passthrough.rs
+++ b/framework_lib/src/chromium_ec/i2c_passthrough.rs
@@ -179,6 +179,11 @@ pub fn i2c_read_16bit_addr(
     let res: _EcI2cPassthruResponse = unsafe { std::ptr::read(data.as_ptr() as *const _) };
     let res_data = &data[size_of::<_EcI2cPassthruResponse>()..];
     debug_assert!(res.messages as usize == messages.len() || res.messages == 0);
+    trace!(
+        "  i2c_read_16bit_addr response (len: {}, data: {:#04X?})",
+        res_data.len(),
+        res_data.to_vec()
+    );
     Ok(EcI2cPassthruResponse {
         i2c_status: res.i2c_status,
         data: res_data.to_vec(),

--- a/framework_lib/src/chromium_ec/i2c_passthrough.rs
+++ b/framework_lib/src/chromium_ec/i2c_passthrough.rs
@@ -177,7 +177,9 @@ pub fn i2c_read_16bit_addr(
 
     let data = ec.send_command(EcCommands::I2cPassthrough as u16, 0, &buffer)?;
     let res: _EcI2cPassthruResponse = unsafe { std::ptr::read(data.as_ptr() as *const _) };
-    let res_data = &data[size_of::<_EcI2cPassthruResponse>()..];
+    let header_len: usize = size_of::<_EcI2cPassthruResponse>();
+    /* Note on windows, you can get extra bytes back, so truncate this to the requested size */
+    let res_data = &data[header_len..(len as usize + header_len)];
     debug_assert!(res.messages as usize == messages.len() || res.messages == 0);
     trace!(
         "  i2c_read_16bit_addr response (len: {}, data: {:#04X?})",

--- a/framework_lib/src/chromium_ec/mod.rs
+++ b/framework_lib/src/chromium_ec/mod.rs
@@ -1551,7 +1551,7 @@ impl CrosEc {
                 "Invalid descriptor hdr magic".to_string(),
             ));
         }
-        self.read_ec_gpu_chunk(0x00, header.descriptor_length as u16)
+        self.read_ec_gpu_chunk(0x00, (header.descriptor_length + header.length) as u16)
     }
 
     pub fn read_gpu_desc_header(&self) -> EcResult<GpuCfgDescriptor> {


### PR DESCRIPTION
1. This fixes an invalid read length that was truncating reads from the GPU descriptor EEPROM as the length is header+descriptor. 

2. This also fixes an issue on windows, where the i2c read will return extra bytes, so we just truncate the extra bytes to the expected response length.