### PR TITLE
Add --pd-debug to control EC PD debug logging

### DIFF
--- a/framework_lib/src/chromium_ec/command.rs
+++ b/framework_lib/src/chromium_ec/command.rs
@@ -127,6 +127,8 @@ pub enum EcCommands {
     GetPdPortState = 0x3E23,
     /// Read board ID of specific ADC channel
     ReadBoardId = 0x3E26,
+    /// Control PD debug logging, the output goes to the EC console
+    DebugControl = 0x3E2D,
 }
 
 pub trait EcRequest<R> {

--- a/framework_lib/src/chromium_ec/commands.rs
+++ b/framework_lib/src/chromium_ec/commands.rs
@@ -1999,3 +1999,33 @@ impl EcRequest<EcResponseGetApThrottleStatus> for EcRequestGetApThrottleStatus {
         EcCommands::GetApThrottleStatus
     }
 }
+
+/// Verbose PD message logging (cypdctl verbose)
+pub const EC_DEBUG_PD_VERBOSE_MSG: u8 = 0x01;
+/// UCSI command tracing (cypdctl ucsi)
+pub const EC_DEBUG_PD_UCSI: u8 = 0x02;
+/// Disable the UCSI tunnel (cypdctl ucsitun 0)
+pub const EC_DEBUG_PD_UCSI_TUNNEL_DIS: u8 = 0x04;
+/// Log every HID report from the keyboard controller (kbdebug)
+pub const EC_DEBUG_KEYBOARD: u8 = 0x08;
+
+#[repr(C, packed)]
+pub struct EcRequestDebugControl {
+    /// Which EC_DEBUG_* flags to modify; 0 = pure read, nothing changed
+    pub set_mask: u8,
+    /// New values for the flags selected in set_mask
+    pub flags: u8,
+}
+
+#[repr(C, packed)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct EcResponseDebugControl {
+    /// Current flag values, after any modification
+    pub flags: u8,
+}
+
+impl EcRequest<EcResponseDebugControl> for EcRequestDebugControl {
+    fn command_id() -> EcCommands {
+        EcCommands::DebugControl
+    }
+}

--- a/framework_lib/src/chromium_ec/mod.rs
+++ b/framework_lib/src/chromium_ec/mod.rs
@@ -863,6 +863,14 @@ impl CrosEc {
         }
     }
 
+    /// Get or set verbose debug logging flags (see EC_DEBUG_* constants)
+    /// set_mask selects which flags to change, 0 reads without changing.
+    /// Returns the current flags. The log output goes to the EC console.
+    pub fn debug_control(&self, set_mask: u8, flags: u8) -> EcResult<u8> {
+        let res = EcRequestDebugControl { set_mask, flags }.send_command(self)?;
+        Ok(res.flags)
+    }
+
     /// Set tablet mode
     pub fn set_tablet_mode(&self, mode: TabletModeOverride) {
         let mode = mode as u8;

--- a/framework_lib/src/commandline/clap_std.rs
+++ b/framework_lib/src/commandline/clap_std.rs
@@ -16,7 +16,7 @@ use crate::chromium_ec::commands::SetGpuSerialMagic;
 use crate::chromium_ec::CrosEcDriverType;
 use crate::commandline::{
     Cli, ClickForceArg, ConsoleArg, FpBrightnessArg, HardwareDeviceType, InputDeckModeArg,
-    LogLevel, RebootEcArg, TabletModeArg,
+    KbdDebugArg, LogLevel, PdDebugArg, RebootEcArg, TabletModeArg,
 };
 
 /// Swiss army knife for Framework laptops
@@ -128,6 +128,16 @@ struct ClapCli {
     /// Enable all ports on a specific PD controller (for debugging only)
     #[arg(long)]
     pd_enable: Option<u8>,
+
+    /// Get or set PD debug logging, read the output via --console
+    #[clap(value_enum)]
+    #[arg(long)]
+    pd_debug: Option<PdDebugArg>,
+
+    /// Get or set keyboard controller debug logging, read the output via --console
+    #[clap(value_enum)]
+    #[arg(long)]
+    kbd_debug: Option<KbdDebugArg>,
 
     /// Show details about connected DP or HDMI Expansion Cards
     #[arg(long)]
@@ -655,6 +665,8 @@ pub fn parse(args: &[String]) -> Cli {
         pd_reset: args.pd_reset,
         pd_disable: args.pd_disable,
         pd_enable: args.pd_enable,
+        pd_debug: args.pd_debug,
+        kbd_debug: args.kbd_debug,
         dp_hdmi_info: args.dp_hdmi_info,
         dp_hdmi_update: args
             .dp_hdmi_update

--- a/framework_lib/src/commandline/mod.rs
+++ b/framework_lib/src/commandline/mod.rs
@@ -42,6 +42,9 @@ use crate::chromium_ec::commands::RebootEcCmd;
 use crate::chromium_ec::commands::RgbS;
 use crate::chromium_ec::commands::TabletModeOverride;
 use crate::chromium_ec::commands::EC_PROTOCOL_INFO_IN_PROGRESS_SUPPORTED;
+use crate::chromium_ec::commands::{
+    EC_DEBUG_KEYBOARD, EC_DEBUG_PD_UCSI, EC_DEBUG_PD_UCSI_TUNNEL_DIS, EC_DEBUG_PD_VERBOSE_MSG,
+};
 use crate::chromium_ec::commands::{PORT_80_EVENT_RESET, PORT_80_EVENT_RESUME};
 use crate::chromium_ec::EcResponseStatus;
 use crate::chromium_ec::Port80History;
@@ -97,6 +100,24 @@ pub enum TabletModeArg {
 pub enum ConsoleArg {
     Recent,
     Follow,
+}
+
+#[cfg_attr(not(feature = "uefi"), derive(clap::ValueEnum))]
+#[derive(Clone, Debug, PartialEq)]
+pub enum PdDebugArg {
+    Status,
+    Off,
+    Verbose,
+    Ucsi,
+    All,
+}
+
+#[cfg_attr(not(feature = "uefi"), derive(clap::ValueEnum))]
+#[derive(Clone, Debug, PartialEq)]
+pub enum KbdDebugArg {
+    Status,
+    Off,
+    On,
 }
 
 #[cfg_attr(not(feature = "uefi"), derive(clap::ValueEnum))]
@@ -207,6 +228,8 @@ pub struct Cli {
     pub pd_reset: Option<u8>,
     pub pd_disable: Option<u8>,
     pub pd_enable: Option<u8>,
+    pub pd_debug: Option<PdDebugArg>,
+    pub kbd_debug: Option<KbdDebugArg>,
     pub dp_hdmi_info: bool,
     pub dp_hdmi_update: Option<String>,
     pub audio_card_info: bool,
@@ -308,6 +331,8 @@ pub fn parse(args: &[String]) -> Cli {
             // pd_reset
             // pd_disable
             // pd_enable
+            // pd_debug
+            // kbd_debug
             dp_hdmi_info: cli.dp_hdmi_info,
             // dp_hdmi_update
             audio_card_info: cli.audio_card_info,
@@ -1777,6 +1802,50 @@ pub fn run_with_args(args: &Cli, _allupdate: bool) -> i32 {
                 Ok(())
             }
         });
+    } else if let Some(pd_debug) = &args.pd_debug {
+        let (set_mask, flags) = match pd_debug {
+            PdDebugArg::Status => (0, 0),
+            PdDebugArg::Off => (EC_DEBUG_PD_VERBOSE_MSG | EC_DEBUG_PD_UCSI, 0),
+            PdDebugArg::Verbose => (EC_DEBUG_PD_VERBOSE_MSG, EC_DEBUG_PD_VERBOSE_MSG),
+            PdDebugArg::Ucsi => (EC_DEBUG_PD_UCSI, EC_DEBUG_PD_UCSI),
+            PdDebugArg::All => (
+                EC_DEBUG_PD_VERBOSE_MSG | EC_DEBUG_PD_UCSI,
+                EC_DEBUG_PD_VERBOSE_MSG | EC_DEBUG_PD_UCSI,
+            ),
+        };
+        match ec.debug_control(set_mask, flags) {
+            Ok(cur) => {
+                println!("PD debug logging:");
+                println!(
+                    "  Verbose:              {}",
+                    cur & EC_DEBUG_PD_VERBOSE_MSG != 0
+                );
+                println!("  UCSI:                 {}", cur & EC_DEBUG_PD_UCSI != 0);
+                println!(
+                    "  UCSI tunnel disabled: {}",
+                    cur & EC_DEBUG_PD_UCSI_TUNNEL_DIS != 0
+                );
+                if cur & (EC_DEBUG_PD_VERBOSE_MSG | EC_DEBUG_PD_UCSI) != 0 {
+                    println!("Read the log output with --console follow");
+                }
+            }
+            Err(err) => println!("Failed to control PD debug logging: {:?}", err),
+        }
+    } else if let Some(kbd_debug) = &args.kbd_debug {
+        let (set_mask, flags) = match kbd_debug {
+            KbdDebugArg::Status => (0, 0),
+            KbdDebugArg::Off => (EC_DEBUG_KEYBOARD, 0),
+            KbdDebugArg::On => (EC_DEBUG_KEYBOARD, EC_DEBUG_KEYBOARD),
+        };
+        match ec.debug_control(set_mask, flags) {
+            Ok(cur) => {
+                println!("Keyboard debug logging: {}", cur & EC_DEBUG_KEYBOARD != 0);
+                if cur & EC_DEBUG_KEYBOARD != 0 {
+                    println!("Read the log output with --console follow");
+                }
+            }
+            Err(err) => println!("Failed to control keyboard debug logging: {:?}", err),
+        }
     } else if args.dp_hdmi_info {
         #[cfg(feature = "hidapi")]
         print_dp_hdmi_details(true);
@@ -2104,6 +2173,8 @@ Options:
                              Set the color of a key to RGB. Multiple colors for adjacent keys can be set at once
       --tablet-mode <MODE>   Set tablet mode override [possible values: auto, tablet, laptop]
       --console <CONSOLE>    Get EC console, choose whether recent or to follow the output [possible values: recent, follow]
+      --pd-debug <MODE>      Get or set PD debug logging, read it via --console [possible values: status, off, verbose, ucsi, all]
+      --kbd-debug <MODE>     Get or set keyboard controller debug logging, read it via --console [possible values: status, off, on]
       --hash <HASH>          Hash a file of arbitrary data
       --flash-gpu-descriptor <MAGIC> <18 DIGIT SN> Overwrite the GPU bay descriptor SN and type.
       --flash-gpu-descriptor-file <DESCRIPTOR_FILE> Write the GPU bay descriptor with a descriptor file.

--- a/framework_lib/src/commandline/uefi.rs
+++ b/framework_lib/src/commandline/uefi.rs
@@ -11,7 +11,10 @@ use crate::chromium_ec::commands::SetGpuSerialMagic;
 use crate::chromium_ec::{CrosEcDriverType, HardwareDeviceType};
 use crate::commandline::{Cli, LogLevel};
 
-use super::{ConsoleArg, FpBrightnessArg, InputDeckModeArg, RebootEcArg, TabletModeArg};
+use super::{
+    ConsoleArg, FpBrightnessArg, InputDeckModeArg, KbdDebugArg, PdDebugArg, RebootEcArg,
+    TabletModeArg,
+};
 
 /// Get commandline arguments from UEFI environment
 pub fn get_args() -> Vec<String> {
@@ -55,6 +58,8 @@ pub fn parse(args: &[String]) -> Cli {
         pd_reset: None,
         pd_disable: None,
         pd_enable: None,
+        pd_debug: None,
+        kbd_debug: None,
         dp_hdmi_info: false,
         dp_hdmi_update: None,
         audio_card_info: false,
@@ -659,6 +664,52 @@ pub fn parse(args: &[String]) -> Cli {
                 }
             } else {
                 println!("--pd-enable requires specifying the PD controller");
+                None
+            };
+            found_an_option = true;
+        } else if arg == "--pd-debug" {
+            cli.pd_debug = if args.len() > i + 1 {
+                let pd_debug_arg = &args[i + 1];
+                if pd_debug_arg == "status" {
+                    Some(PdDebugArg::Status)
+                } else if pd_debug_arg == "off" {
+                    Some(PdDebugArg::Off)
+                } else if pd_debug_arg == "verbose" {
+                    Some(PdDebugArg::Verbose)
+                } else if pd_debug_arg == "ucsi" {
+                    Some(PdDebugArg::Ucsi)
+                } else if pd_debug_arg == "all" {
+                    Some(PdDebugArg::All)
+                } else {
+                    println!(
+                        "Invalid value for --pd-debug: '{}'. Must be one of 'status', 'off', 'verbose', 'ucsi', 'all'.",
+                        pd_debug_arg
+                    );
+                    None
+                }
+            } else {
+                println!("--pd-debug requires specifying the mode");
+                None
+            };
+            found_an_option = true;
+        } else if arg == "--kbd-debug" {
+            cli.kbd_debug = if args.len() > i + 1 {
+                let kbd_debug_arg = &args[i + 1];
+                if kbd_debug_arg == "status" {
+                    Some(KbdDebugArg::Status)
+                } else if kbd_debug_arg == "off" {
+                    Some(KbdDebugArg::Off)
+                } else if kbd_debug_arg == "on" {
+                    Some(KbdDebugArg::On)
+                } else {
+                    println!(
+                        "Invalid value for --kbd-debug: '{}'. Must be one of 'status', 'off', 'on'.",
+                        kbd_debug_arg
+                    );
+                    None
+                }
+            } else {
+                println!("--kbd-debug requires specifying the mode");
                 None
             };
             found_an_option = true;

--- a/framework_tool/completions/bash/framework_tool
+++ b/framework_tool/completions/bash/framework_tool
@@ -23,7 +23,7 @@ _framework_tool() {
 
     case "${cmd}" in
         framework_tool)
-            opts="-v -q -t -f -h --flash-gpu-descriptor --verbose --quiet --versions --version --features --esrt --device --compare-version --power --smartbattery --smartbattery-auth --thermal --thermalget --thermalset --sensors --fansetduty --fansetrpm --autofanctrl --pdports --pdports-chromebook --info --meinfo --pd-info --pd-reset --pd-disable --pd-enable --dp-hdmi-info --dp-hdmi-update --audio-card-info --privacy --pd-bin --ec-bin --capsule --dump --h2o-capsule --dump-ec-flash --flash-full-ec --flash-ec --flash-ro-ec --flash-rw-ec --intrusion --inputdeck --inputdeck-mode --expansion-bay --charge-limit --charge-current-limit --charge-rate-limit --get-gpio --fp-led-level --fp-brightness --kblight --remap-key --rgbkbd --ps2-enable --tablet-mode --touchscreen-enable --haptic-intensity --click-force --stylus-battery --console --reboot-ec --ec-hib-delay --sysinfo --uptimeinfo --s0ix-counter --hello --protoinfo --switches --port80read --panicinfo --hash --driver --pd-addrs --pd-ports --test --test-retimer --boardid --force --dry-run --flash-gpu-descriptor-file --dump-gpu-descriptor-file --validate-gpu-descriptor-file --nvidia --host-command --generate-completions --generate-manpage --help"
+            opts="-v -q -t -f -h --flash-gpu-descriptor --verbose --quiet --versions --version --features --esrt --device --compare-version --power --smartbattery --smartbattery-auth --thermal --thermalget --thermalset --sensors --fansetduty --fansetrpm --autofanctrl --pdports --pdports-chromebook --info --meinfo --pd-info --pd-reset --pd-disable --pd-enable --pd-debug --kbd-debug --dp-hdmi-info --dp-hdmi-update --audio-card-info --privacy --pd-bin --ec-bin --capsule --dump --h2o-capsule --dump-ec-flash --flash-full-ec --flash-ec --flash-ro-ec --flash-rw-ec --intrusion --inputdeck --inputdeck-mode --expansion-bay --charge-limit --charge-current-limit --charge-rate-limit --get-gpio --fp-led-level --fp-brightness --kblight --remap-key --rgbkbd --ps2-enable --tablet-mode --touchscreen-enable --haptic-intensity --click-force --stylus-battery --console --reboot-ec --ec-hib-delay --sysinfo --uptimeinfo --s0ix-counter --hello --protoinfo --switches --port80read --panicinfo --hash --driver --pd-addrs --pd-ports --test --test-retimer --boardid --force --dry-run --flash-gpu-descriptor-file --dump-gpu-descriptor-file --validate-gpu-descriptor-file --nvidia --host-command --generate-completions --generate-manpage --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -75,6 +75,14 @@ _framework_tool() {
                     ;;
                 --pd-enable)
                     COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --pd-debug)
+                    COMPREPLY=($(compgen -W "status off verbose ucsi all" -- "${cur}"))
+                    return 0
+                    ;;
+                --kbd-debug)
+                    COMPREPLY=($(compgen -W "status off on" -- "${cur}"))
                     return 0
                     ;;
                 --dp-hdmi-update)

--- a/framework_tool/completions/fish/framework_tool.fish
+++ b/framework_tool/completions/fish/framework_tool.fish
@@ -17,6 +17,14 @@ complete -c framework_tool -l meinfo -d 'Show Intel ME information (from SMBIOS 
 complete -c framework_tool -l pd-reset -d 'Reset a specific PD controller (for debugging only)' -r
 complete -c framework_tool -l pd-disable -d 'Disable all ports on a specific PD controller (for debugging only)' -r
 complete -c framework_tool -l pd-enable -d 'Enable all ports on a specific PD controller (for debugging only)' -r
+complete -c framework_tool -l pd-debug -d 'Get or set PD debug logging, read the output via --console' -r -f -a "status\t''
+off\t''
+verbose\t''
+ucsi\t''
+all\t''"
+complete -c framework_tool -l kbd-debug -d 'Get or set keyboard controller debug logging, read the output via --console' -r -f -a "status\t''
+off\t''
+on\t''"
 complete -c framework_tool -l dp-hdmi-update -d 'Update the DisplayPort or HDMI Expansion Card' -r -F
 complete -c framework_tool -l pd-bin -d 'Parse versions from PD firmware binary file' -r -F
 complete -c framework_tool -l ec-bin -d 'Parse versions from EC firmware binary file' -r -F

--- a/framework_tool/completions/zsh/_framework_tool
+++ b/framework_tool/completions/zsh/_framework_tool
@@ -27,6 +27,8 @@ _framework_tool() {
 '--pd-reset=[Reset a specific PD controller (for debugging only)]:PD_RESET:_default' \
 '--pd-disable=[Disable all ports on a specific PD controller (for debugging only)]:PD_DISABLE:_default' \
 '--pd-enable=[Enable all ports on a specific PD controller (for debugging only)]:PD_ENABLE:_default' \
+'--pd-debug=[Get or set PD debug logging, read the output via --console]:PD_DEBUG:(status off verbose ucsi all)' \
+'--kbd-debug=[Get or set keyboard controller debug logging, read the output via --console]:KBD_DEBUG:(status off on)' \
 '--dp-hdmi-update=[Update the DisplayPort or HDMI Expansion Card]:UPDATE_BIN:_files' \
 '--pd-bin=[Parse versions from PD firmware binary file]:PD_BIN:_files' \
 '--ec-bin=[Parse versions from EC firmware binary file]:EC_BIN:_files' \

--- a/framework_tool/framework_tool.1
+++ b/framework_tool/framework_tool.1
@@ -8,7 +8,7 @@ framework_tool \- Swiss army knife for Framework laptops
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
 .SH SYNOPSIS
-\fBframework_tool\fR [\fB\-\-flash\-gpu\-descriptor\fR] [\fB\-v\fR|\fB\-\-verbose\fR]... [\fB\-q\fR|\fB\-\-quiet\fR]... [\fB\-\-versions\fR] [\fB\-\-version\fR] [\fB\-\-features\fR] [\fB\-\-esrt\fR] [\fB\-\-device\fR] [\fB\-\-compare\-version\fR] [\fB\-\-power\fR] [\fB\-\-smartbattery\fR] [\fB\-\-smartbattery\-auth\fR] [\fB\-\-thermal\fR] [\fB\-\-thermalget\fR] [\fB\-\-thermalset\fR] [\fB\-\-sensors\fR] [\fB\-\-fansetduty\fR] [\fB\-\-fansetrpm\fR] [\fB\-\-autofanctrl\fR] [\fB\-\-pdports\fR] [\fB\-\-pdports\-chromebook\fR] [\fB\-\-info\fR] [\fB\-\-meinfo\fR] [\fB\-\-pd\-info\fR] [\fB\-\-pd\-reset\fR] [\fB\-\-pd\-disable\fR] [\fB\-\-pd\-enable\fR] [\fB\-\-dp\-hdmi\-info\fR] [\fB\-\-dp\-hdmi\-update\fR] [\fB\-\-audio\-card\-info\fR] [\fB\-\-privacy\fR] [\fB\-\-pd\-bin\fR] [\fB\-\-ec\-bin\fR] [\fB\-\-capsule\fR] [\fB\-\-dump\fR] [\fB\-\-h2o\-capsule\fR] [\fB\-\-dump\-ec\-flash\fR] [\fB\-\-flash\-full\-ec\fR] [\fB\-\-flash\-ec\fR] [\fB\-\-flash\-ro\-ec\fR] [\fB\-\-flash\-rw\-ec\fR] [\fB\-\-intrusion\fR] [\fB\-\-inputdeck\fR] [\fB\-\-inputdeck\-mode\fR] [\fB\-\-expansion\-bay\fR] [\fB\-\-charge\-limit\fR] [\fB\-\-charge\-current\-limit\fR] [\fB\-\-charge\-rate\-limit\fR] [\fB\-\-get\-gpio\fR] [\fB\-\-fp\-led\-level\fR] [\fB\-\-fp\-brightness\fR] [\fB\-\-kblight\fR] [\fB\-\-remap\-key\fR] [\fB\-\-rgbkbd\fR] [\fB\-\-tablet\-mode\fR] [\fB\-\-touchscreen\-enable\fR] [\fB\-\-haptic\-intensity\fR] [\fB\-\-click\-force\fR] [\fB\-\-stylus\-battery\fR] [\fB\-\-console\fR] [\fB\-\-reboot\-ec\fR] [\fB\-\-ec\-hib\-delay\fR] [\fB\-\-sysinfo\fR] [\fB\-\-uptimeinfo\fR] [\fB\-\-s0ix\-counter\fR] [\fB\-\-hello\fR] [\fB\-\-protoinfo\fR] [\fB\-\-switches\fR] [\fB\-\-port80read\fR] [\fB\-\-panicinfo\fR] [\fB\-\-hash\fR] [\fB\-\-driver\fR] [\fB\-\-pd\-addrs\fR] [\fB\-\-pd\-ports\fR] [\fB\-t\fR|\fB\-\-test\fR] [\fB\-\-test\-retimer\fR] [\fB\-\-boardid\fR] [\fB\-f\fR|\fB\-\-force\fR] [\fB\-\-dry\-run\fR] [\fB\-\-flash\-gpu\-descriptor\-file\fR] [\fB\-\-dump\-gpu\-descriptor\-file\fR] [\fB\-\-validate\-gpu\-descriptor\-file\fR] [\fB\-\-nvidia\fR] [\fB\-\-host\-command\fR] [\fB\-h\fR|\fB\-\-help\fR] 
+\fBframework_tool\fR [\fB\-\-flash\-gpu\-descriptor\fR] [\fB\-v\fR|\fB\-\-verbose\fR]... [\fB\-q\fR|\fB\-\-quiet\fR]... [\fB\-\-versions\fR] [\fB\-\-version\fR] [\fB\-\-features\fR] [\fB\-\-esrt\fR] [\fB\-\-device\fR] [\fB\-\-compare\-version\fR] [\fB\-\-power\fR] [\fB\-\-smartbattery\fR] [\fB\-\-smartbattery\-auth\fR] [\fB\-\-thermal\fR] [\fB\-\-thermalget\fR] [\fB\-\-thermalset\fR] [\fB\-\-sensors\fR] [\fB\-\-fansetduty\fR] [\fB\-\-fansetrpm\fR] [\fB\-\-autofanctrl\fR] [\fB\-\-pdports\fR] [\fB\-\-pdports\-chromebook\fR] [\fB\-\-info\fR] [\fB\-\-meinfo\fR] [\fB\-\-pd\-info\fR] [\fB\-\-pd\-reset\fR] [\fB\-\-pd\-disable\fR] [\fB\-\-pd\-enable\fR] [\fB\-\-pd\-debug\fR] [\fB\-\-kbd\-debug\fR] [\fB\-\-dp\-hdmi\-info\fR] [\fB\-\-dp\-hdmi\-update\fR] [\fB\-\-audio\-card\-info\fR] [\fB\-\-privacy\fR] [\fB\-\-pd\-bin\fR] [\fB\-\-ec\-bin\fR] [\fB\-\-capsule\fR] [\fB\-\-dump\fR] [\fB\-\-h2o\-capsule\fR] [\fB\-\-dump\-ec\-flash\fR] [\fB\-\-flash\-full\-ec\fR] [\fB\-\-flash\-ec\fR] [\fB\-\-flash\-ro\-ec\fR] [\fB\-\-flash\-rw\-ec\fR] [\fB\-\-intrusion\fR] [\fB\-\-inputdeck\fR] [\fB\-\-inputdeck\-mode\fR] [\fB\-\-expansion\-bay\fR] [\fB\-\-charge\-limit\fR] [\fB\-\-charge\-current\-limit\fR] [\fB\-\-charge\-rate\-limit\fR] [\fB\-\-get\-gpio\fR] [\fB\-\-fp\-led\-level\fR] [\fB\-\-fp\-brightness\fR] [\fB\-\-kblight\fR] [\fB\-\-remap\-key\fR] [\fB\-\-rgbkbd\fR] [\fB\-\-tablet\-mode\fR] [\fB\-\-touchscreen\-enable\fR] [\fB\-\-haptic\-intensity\fR] [\fB\-\-click\-force\fR] [\fB\-\-stylus\-battery\fR] [\fB\-\-console\fR] [\fB\-\-reboot\-ec\fR] [\fB\-\-ec\-hib\-delay\fR] [\fB\-\-sysinfo\fR] [\fB\-\-uptimeinfo\fR] [\fB\-\-s0ix\-counter\fR] [\fB\-\-hello\fR] [\fB\-\-protoinfo\fR] [\fB\-\-switches\fR] [\fB\-\-port80read\fR] [\fB\-\-panicinfo\fR] [\fB\-\-hash\fR] [\fB\-\-driver\fR] [\fB\-\-pd\-addrs\fR] [\fB\-\-pd\-ports\fR] [\fB\-t\fR|\fB\-\-test\fR] [\fB\-\-test\-retimer\fR] [\fB\-\-boardid\fR] [\fB\-f\fR|\fB\-\-force\fR] [\fB\-\-dry\-run\fR] [\fB\-\-flash\-gpu\-descriptor\-file\fR] [\fB\-\-dump\-gpu\-descriptor\-file\fR] [\fB\-\-validate\-gpu\-descriptor\-file\fR] [\fB\-\-nvidia\fR] [\fB\-\-host\-command\fR] [\fB\-h\fR|\fB\-\-help\fR] 
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
 .SH DESCRIPTION
@@ -123,6 +123,40 @@ Disable all ports on a specific PD controller (for debugging only)
 .TP
 \fB\-\-pd\-enable\fR \fI<PD_ENABLE>\fR
 Enable all ports on a specific PD controller (for debugging only)
+.TP
+\fB\-\-pd\-debug\fR \fI<PD_DEBUG>\fR
+Get or set PD debug logging, read the output via \-\-console
+.br
+
+.br
+\fIPossible values:\fR
+.RS 14
+.IP \(bu 2
+status
+.IP \(bu 2
+off
+.IP \(bu 2
+verbose
+.IP \(bu 2
+ucsi
+.IP \(bu 2
+all
+.RE
+.TP
+\fB\-\-kbd\-debug\fR \fI<KBD_DEBUG>\fR
+Get or set keyboard controller debug logging, read the output via \-\-console
+.br
+
+.br
+\fIPossible values:\fR
+.RS 14
+.IP \(bu 2
+status
+.IP \(bu 2
+off
+.IP \(bu 2
+on
+.RE
 .TP
 \fB\-\-dp\-hdmi\-info\fR
 Show details about connected DP or HDMI Expansion Cards


### PR DESCRIPTION
Uses the new EC_CMD_PD_DEBUG_CONTROL (0x3E2D) host command to toggle the verbose PD message logging and UCSI command tracing that could previously only be enabled with the cypdctl EC console command.

The log output goes to the EC console, read it with --console follow.

  > framework_tool --pd-debug status
  PD debug logging:
    Verbose:              false
    UCSI:                 false
    UCSI tunnel disabled: false
  > framework_tool --pd-debug verbose
  > framework_tool --console follow